### PR TITLE
Use CL-SYSLOG

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -8,6 +8,10 @@
 
 (defvar *entered-from-main* nil)
 (defvar *program-name* "qvm")
+(defvar *logger* (make-instance 'cl-syslog:rfc5424-logger
+                                :app-name "qvm"
+                                :facility ':local0
+                                :log-writer (cl-syslog:null-log-writer)))
 
 (defparameter *benchmark-types* '("bell" "qft" "hadamard" #-forest-sdk "suite")
   "List of allowed benchmark names.")
@@ -452,6 +456,12 @@ Copyright (c) 2018 Rigetti Computing.~2%")
 (defun %main (argv)
   (setup-debugger)
   (setf *entered-from-main* t)
+
+  (setf *logger* (make-instance 'cl-syslog:rfc5424-logger
+                                :app-name "qvm"
+                                :facility ':local0
+                                :log-writer (cl-syslog:tee-to-stream
+                                             (cl-syslog:syslog-log-writer "qvm" :local0))))
 
   ;; This finalizer can _always_ be called even if there is no
   ;; persistent wavefunction. Also, we note that the library

--- a/app/src/server-abstraction.lisp
+++ b/app/src/server-abstraction.lisp
@@ -26,6 +26,29 @@
          s))
       (call-next-method)))
 
+(defmethod tbnl:acceptor-log-access ((acceptor vhost) &key return-code)
+  (cl-syslog:format-log *logger* ':info
+                        "~:[-~@[ (~A)~]~;~:*~A~@[ (~A)~]~] ~:[-~;~:*~A~] [~A] \"~A ~A~@[?~A~] ~
+                          ~A\" ~D ~:[-~;~:*~D~] \"~:[-~;~:*~A~]\" \"~:[-~;~:*~A~]\"~%"
+                        (tbnl::remote-addr*)
+                        (tbnl::header-in* :x-forwarded-for)
+                        (tbnl::authorization)
+                        (tbnl::iso-time)
+                        (tbnl::request-method*)
+                        (tbnl::script-name*)
+                        (tbnl::query-string*)
+                        (tbnl::server-protocol*)
+                        return-code
+                        (tbnl::content-length*)
+                        (tbnl::referer)
+                        (tbnl::user-agent)))
+
+(defmethod tbnl:acceptor-log-message ((acceptor vhost) log-level format-string &rest format-arguments)
+  (cl-syslog:format-log *logger* ':err
+                        "[~A~@[ [~A]~]] ~?~%"
+                        (tbnl::iso-time) log-level
+                        format-string format-arguments))
+
 (defun create-prefix/method-dispatcher (prefix method handler)
   "Creates a request dispatch function which will dispatch to the
 function denoted by HANDLER if the file name of the current request

--- a/app/src/utilities.lisp
+++ b/app/src/utilities.lisp
@@ -93,12 +93,6 @@
               (tbnl:session-id tbnl:*session*))))
 
 (defun format-log (fmt-string &rest args)
-  (cond
-    ((boundp 'tbnl:*acceptor*)
-     (apply #'tbnl:log-message* ':INFO
-            (concatenate 'string (session-info) fmt-string)
-            args))
-    (t
-     (format t "[~A] ~?" (tbnl::iso-time) fmt-string args)
-     (terpri))))
+  (apply #'cl-syslog:format-log *logger* ':info (concatenate 'string "~A" fmt-string) (session-info) args))
+
 

--- a/qvm-app.asd
+++ b/qvm-app.asd
@@ -35,7 +35,9 @@
                ;; Portable gc
                #:trivial-garbage
                ;; Portable globals
-               #:global-vars)
+               #:global-vars
+               ;; Logging
+               #:cl-syslog)
   :in-order-to ((asdf:test-op (asdf:test-op #:qvm-app-tests)))
   :pathname "app/src/"
   :serial t


### PR DESCRIPTION
Use `cl-syslog` in place of `format-log`.

Output of a typical QVM session:
```
./qvm -S
******************************
* Welcome to the Rigetti QVM *
******************************
Copyright (c) 2018 Rigetti Computing.

(Configured with 2048 MiB of workspace and 8 workers.)

<134>1 2019-01-22T20:46:41Z skilbeck-macbook.local qvm-app 48188 - - Selected simulation method: pure-state
<134>1 2019-01-22T20:46:41Z skilbeck-macbook.local qvm-app 48188 - - Starting server on port 5000.
<134>1 2019-01-22T20:46:51Z skilbeck-macbook.local qvm-app 48188 - - Got "multishot" request from API key/User ID: NIL / NIL
<134>1 2019-01-22T20:46:51Z skilbeck-macbook.local qvm-app 48188 - - Making qvm of 8 qubits
<134>1 2019-01-22T20:46:51Z skilbeck-macbook.local qvm-app 48188 - - Running experiment with 5 trials on PURE-STATE-QVM
<134>1 2019-01-22T20:46:51Z skilbeck-macbook.local qvm-app 48188 - - Finished in 5 ms
127.0.0.1 - [2019-01-22 12:46:51] "POST /qvm HTTP/1.1" 200 98 "-" "python-requests/2.20.1"
```
Not sure where that last non syslog message is coming from. Huchentoot I guess.