### PR TITLE
Add basic PULSE-TRACING-QVM

### DIFF
--- a/qvm-tests.asd
+++ b/qvm-tests.asd
@@ -33,6 +33,7 @@
                (:file "modifier-tests")
                (:file "noisy-qvm-tests")
                (:file "density-qvm-tests")
+               (:file "pulse-tracing-qvm-tests")
                (:file "stress-tests")
                (:file "path-simulate-tests")
                (:file "stabilizer-qvm-tests")

--- a/qvm.asd
+++ b/qvm.asd
@@ -76,6 +76,7 @@
                (:file "depolarizing-noise")
                (:file "noisy-qvm")
                (:file "density-qvm")
+               (:file "pulse-tracing-qvm")
                (:file "stabilizer-qvm")
                (:file "execution")
                (:file "path-simulate")

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -156,6 +156,12 @@
    #:set-noisy-gate                     ; GENERIC, METHOD
    )
 
+  ;; pulse-tracing-qvm.lisp
+  (:export
+   #:pulse-tracing-qvm
+   #:trace-quilt-program
+   )
+
   ;; density-qvm
   (:export
    #:density-qvm                        ; CLASS

--- a/src/pulse-tracing-qvm.lisp
+++ b/src/pulse-tracing-qvm.lisp
@@ -24,9 +24,6 @@
   (sample-rate (error "Sample rate must be defined.")
    :type real))
 
-(defparameter *initial-pulse-event-log-length* 100
-  "The initial length of the pulse tracing QVM's event log.")
-
 (defclass pulse-tracing-qvm (classical-memory-mixin)
   ((local-clocks :initarg :local-clocks
                  :accessor local-clocks

--- a/src/pulse-tracing-qvm.lisp
+++ b/src/pulse-tracing-qvm.lisp
@@ -36,8 +36,8 @@
    (pulse-event-handlers :initarg :event-handler
                    :accessor pulse-event-handlers
                    :initform nil
-                   :documentation "A list of event handlers, which are called with active PULSE events."))
-  (:documentation "A quantum virtual machine capable of tracing pulse sequences over time."))
+                   :documentation "A list of event handlers, which are called with active PULSE-EVENTs."))
+  (:documentation "A quantum virtual machine capable of producing tracing quilt instructions over time."))
 
 ;;; TODO this fakeness is mainly to make LOAD-PROGRAM happy
 (defmethod number-of-qubits ((qvm pulse-tracing-qvm))
@@ -66,6 +66,7 @@
                               :sample-rate (quil:constant-value sample-rate))))))
 
 (defun install-event-handler (qvm handler)
+  "Install the HANDLER to be called on new pulse events."
   (check-type handler function)
   (push handler (pulse-event-handlers qvm)))
 
@@ -136,11 +137,13 @@
 
 (defmethod transition ((qvm pulse-tracing-qvm) (instr quil:delay-on-qubits))
   (let ((frames (frames-on-qubits qvm (quil:delay-qubits instr))))
+    ;; delegate
     (transition qvm (make-instance 'quil:delay-on-frames
                                    :frames frames
                                    :duration (quil:delay-duration instr)))))
 
 (defun synchronize-frame-clocks (qvm frames)
+  "Bring all clocks on the specified FRAMES to their latest time."
   (let ((latest (apply #'latest-time qvm frames)))
     (dolist (frame frames)
       (setf (local-time qvm frame) latest))))

--- a/src/pulse-tracing-qvm.lisp
+++ b/src/pulse-tracing-qvm.lisp
@@ -61,7 +61,7 @@
                     :initform  (make-array *initial-pulse-event-log-length*
                                            :fill-pointer 0
                                            :adjustable t)
-                    :documentation "A log, in reverse chronological order, of observed pulse events."))
+                    :documentation "A log, in chronological order, of observed pulse events."))
   (:documentation "A quantum virtual machine capable of tracing pulse sequences over time."))
 
 ;;; TODO this fakeness is mainly to make LOAD-PROGRAM happy
@@ -165,7 +165,7 @@ If "
     (when (equalp left-frame right-frame)
       (error "SWAP-PHASE requires distinct frames."))
     (let ((left-state (frame-state qvm left-frame))
-          (right-state (frame-state qvm left-frame)))
+          (right-state (frame-state qvm right-frame)))
       (rotatef (frame-state-phase left-state) (frame-state-phase right-state))
       (setf (frame-state qvm left-frame) left-state
             (frame-state qvm right-frame) right-state)))

--- a/src/pulse-tracing-qvm.lisp
+++ b/src/pulse-tracing-qvm.lisp
@@ -1,0 +1,198 @@
+(in-package :qvm)
+
+;;; TODO is there a better name?
+;;; the event can either be tx or rx
+(defstruct pulse-event
+  instruction
+  start-time
+  end-time
+  frame-state)
+
+;;; TODO move this to cl-quil ast code?
+(defun pulse-op-frame (instr)
+  (etypecase instr
+    (quil:pulse (quil:pulse-frame instr))
+    (quil:capture (quil:capture-frame instr))
+    (quil:raw-capture (quil:raw-capture-frame instr))))
+
+(defun pulse-event-frame (event)
+  "The frame associated with a pulse event."
+  (let ((instr (pulse-event-instruction event)))
+    (pulse-op-frame instr)))
+
+(defun pulse-event-duration (pulse-event)
+  "The duration of a pulse event."
+  (- (pulse-event-end-time pulse-event)
+     (pulse-event-start-time pulse-event)))
+
+;;; A structure tracking the state of a specific frame.
+(defstruct frame-state
+  (phase 0.0d0
+   :type real)
+  (scale 1.0d0
+   :type real)
+  (frequency (error "Frequency must be defined.")
+   :type real))
+
+(defparameter *default-frame-frequency* 1.0 ; TODO get a better default
+  "The default frame frequency.")
+
+(defparameter *initial-pulse-event-log-length* 100
+  "The initial length of the pulse tracing QVM's event log.")
+
+;;; This is pretty barebones, but does make some claims about what is important
+;;; to track. Namely, qubit local time and frame states. We also update a log,
+;;; although TODO in principle this could be more generic (e.g. provide some
+;;; sort of "event consumer" callbacks).
+(defclass pulse-tracing-qvm (classical-memory-mixin)
+  ((sample-rate :initarg :sample-rate
+                :accessor sample-rate
+                :initform (error "A sample rate must be specified.")
+                :documentation "The sample rate in Hz for waveform generation.")
+   (local-clocks :initarg :local-clocks
+                 :accessor local-clocks
+                 :initform (make-hash-table)
+                 :documentation "A table mapping qubit indices to the time of their last activity.")
+   (frame-states :initarg :frame-states
+                 :accessor frame-states
+                 :initform (make-hash-table :test 'equalp) ; TODO move to alist so we can use a custom equality check?
+                 :documentation "A table mapping frames to their active states.")
+   (pulse-event-log :initarg :log
+                    :accessor pulse-event-log
+                    :initform  (make-array *initial-pulse-event-log-length*
+                                           :fill-pointer 0
+                                           :adjustable t)
+                    :documentation "A log, in reverse chronological order, of observed pulse events."))
+  (:documentation "A quantum virtual machine capable of tracing pulse sequences over time."))
+
+;;; TODO this fakeness is mainly to make LOAD-PROGRAM happy
+(defmethod number-of-qubits ((qvm pulse-tracing-qvm))
+  most-positive-fixnum)
+
+(defun make-pulse-tracing-qvm (sample-rate)
+  "Create a new pulse tracing QVM with the specified SAMPLE-RATE."
+  (make-instance 'pulse-tracing-qvm
+                 :sample-rate sample-rate
+                 :classical-memory-subsystem
+                 (make-instance 'classical-memory-subsystem
+                                :classical-memory-model
+                                quil:**empty-memory-model**)))
+
+(defun trace-quilt-program (program &key (sample-rate 100)) ; TODO better magic number
+  "Trace a quilt PROGRAM, returning a list of pulse events."
+  (check-type program quil:parsed-program)
+  (let ((qvm (make-pulse-tracing-qvm sample-rate)))
+    (load-program qvm program)
+    (run qvm)
+    (pulse-event-log qvm)))
+
+(defun local-time (qvm qubit &optional (default 0.0))
+  "Get the local time of QUBIT on the pulse tracing qvm QVM."
+  (check-type qvm pulse-tracing-qvm)
+  (gethash (quil:qubit-index qubit) (local-clocks qvm) default))
+
+(defun (setf local-time) (new-value qvm qubit)
+  "Set the local time of qubit Q on the pulse tracing qvm QVM."
+  (setf (gethash (quil:qubit-index qubit) (local-clocks qvm))
+        new-value))
+
+(defun frame-state (qvm frame)
+  (gethash frame (frame-states qvm)))
+
+(defun (setf frame-state) (new-value qvm frame)
+  (setf (gethash frame (frame-states qvm))
+        new-value))
+
+(defun latest-time (qvm &rest qubits)
+  "Get the latest time of the specified QUBITS on the pulse tracing QVM.
+If "
+  (loop :for q :in qubits :maximize (local-time qvm q)))
+
+(defun new-or-copied-state (qvm frame)
+  "Get a copy of the frame state associated with FRAME on the pulse tracing qvm QVM.
+If there is no associated state, return a new one."
+  (check-type qvm pulse-tracing-qvm)
+  (alexandria:if-let ((fs (frame-state qvm frame)))
+    (copy-structure fs)
+    (make-frame-state :frequency *default-frame-frequency*)))
+
+;;; TRANSITIONs
+
+;;; TODO: right now we support basic quilt instructions: delay, fence, frame
+;;; mutations, pulse, capture, raw-capture
+;;; Do we want more?
+
+(defmethod transition ((qvm pulse-tracing-qvm) (instr quil:delay))
+  (incf (local-time qvm (quil:delay-qubit instr))
+        (quil:delay-duration instr))
+
+  (incf (pc qvm))
+  qvm)
+
+(defmethod transition ((qvm pulse-tracing-qvm) (instr quil:fence))
+  (let ((latest (apply #'latest-time qvm (quil::fence-qubits instr))))
+    (loop :for q :in (quil::fence-qubits instr)
+          :do (setf (local-time qvm q) latest)))
+
+  (incf (pc qvm))
+  qvm)
+
+(defmethod transition ((qvm pulse-tracing-qvm) (instr quil:simple-frame-mutation))
+  (let* ((frame (quil:frame-mutation-target-frame instr))
+         (val (quil:constant-value
+               (quil:frame-mutation-value instr)))
+         (fs (new-or-copied-state qvm frame)))
+
+    ;; update state
+    (etypecase instr
+      (quil:set-frequency
+       (setf (frame-state-frequency fs) val))
+      (quil:set-phase
+       (setf (frame-state-phase fs) val))
+      (quil:shift-phase
+       (incf (frame-state-phase fs) val))
+      (quil:set-scale
+       (setf (frame-state-scale fs) val)))
+
+    ;; update entry
+    (setf (frame-state qvm frame) fs))
+
+  (incf (pc qvm))
+  qvm)
+
+(defmethod transition ((qvm pulse-tracing-qvm) (instr quil:swap-phase))
+  (with-slots (left-frame right-frame) instr
+    (when (equalp left-frame right-frame)
+      (error "SWAP-PHASE requires distinct frames."))
+    (let ((left-state (new-or-copied-state qvm left-frame))
+          (right-state (new-or-copied-state qvm left-frame)))
+      (rotatef (frame-state-phase left-state) (frame-state-phase right-state))
+      (setf (frame-state qvm left-frame) left-state
+            (frame-state qvm right-frame) right-state)))
+
+  (incf (pc qvm))
+  qvm)
+
+(defmethod transition ((qvm pulse-tracing-qvm) instr)
+  (unless (typep instr '(or quil:pulse quil:capture quil:raw-capture))
+    (error "Cannot resolve timing information for non-quilt instruction ~A" instr))
+  (let* ((qubits (quil::quilt-instruction-qubits instr))
+         (start-time (apply #'latest-time qvm qubits))
+         (end-time (+ start-time
+                      (quil::quilt-instruction-duration instr (sample-rate qvm))))
+         (frame-state (frame-state qvm (pulse-op-frame instr))))
+    (unless frame-state                 ; TODO is this a reasonable default?
+      (warn "Instruction ~A references an uninitialized frame." instr)
+      (setf frame-state (make-frame-state :frequency *default-frame-frequency*)))
+    (vector-push-extend (make-pulse-event
+                         :instruction instr
+                         :start-time start-time
+                         :end-time end-time
+                         :frame-state frame-state)
+                        (pulse-event-log qvm))
+    ;; update local times
+    (loop :for q :in qubits
+          :do (setf (local-time qvm q) end-time)))
+
+  (incf (pc qvm))
+  qvm)

--- a/tests/pulse-tracing-qvm-tests.lisp
+++ b/tests/pulse-tracing-qvm-tests.lisp
@@ -1,0 +1,31 @@
+(in-package #:qvm-tests)
+
+;;; TODO: export symbols from QVM
+(deftest test-tracing-simple-quilt-program ()
+  (let ((pp (quil:parse-quil "
+SET-FREQUENCY 0 \"xy\" 1e9
+SET-PHASE 0 \"xy\" 0.5
+PULSE 0 \"xy\" gaussian(duration: 1.0, fwhm: 2, t0: 3)    # 0s-1s
+FENCE 0 1
+PULSE 1 \"xy\" gaussian(duration: 1.0, fwhm: 2, t0: 3)    # 1s-2s
+DECLARE ro BIT[100]
+RAW-CAPTURE 1 \"rx\" 2.0 ro                               # 2s-4s
+PULSE 0 1 \"foo\" flat(duration: 1.5, iq: 1.0)            # 4s-5.5s
+"))
+        (qvm (qvm::make-pulse-tracing-qvm 100))) ; TODO should we bake in a default sample rate here?
+    (load-program qvm pp)
+    (run qvm)
+    ;; check frame state
+    (let* ((frame (quil:frame (list (quil:qubit 0)) "xy"))
+           (state (qvm::frame-state qvm frame)))
+      (is (= 1e9 (qvm::frame-state-frequency state)))
+      (is (- 0.5 (qvm::frame-state-phase state))))
+
+    (let ((log (qvm::pulse-event-log qvm)))
+      ;; check # of events
+      (is (= 4 (length log)))
+      ;; check that the last event has the right timing
+      (let ((event (elt log (1- (length log)))))
+        (is (= 4.0 (qvm::pulse-event-start-time event)))
+        (is (= 5.5 (qvm::pulse-event-end-time event)))
+        (is (= 1.5 (qvm::pulse-event-duration event)))))))

--- a/tests/pulse-tracing-qvm-tests.lisp
+++ b/tests/pulse-tracing-qvm-tests.lisp
@@ -63,6 +63,6 @@ DEFFRAME 0 \"foo\":
 NONBLOCKING PULSE 0 \"xy\" gaussian(duration: 1.0, fwhm: 2, t0: 3)
 PULSE 0 \"foo\" gaussian(duration: 1.5, fwhm: 2, t0: 3)
 PULSE 0 \"xy\" gaussian(duration: 1.0, fwhm: 2, t0: 3)"))
-         (log (qvm::trace-quilt-program pp)))
+         (log (qvm:trace-quilt-program pp)))
     (is (equalp '(0.0 0.0 1.5)
                 (map 'list #'qvm::pulse-event-start-time log)))))

--- a/tests/pulse-tracing-qvm-tests.lisp
+++ b/tests/pulse-tracing-qvm-tests.lisp
@@ -12,7 +12,15 @@ DECLARE ro BIT[100]
 RAW-CAPTURE 1 \"rx\" 2.0 ro                               # 2s-4s
 PULSE 0 1 \"foo\" flat(duration: 1.5, iq: 1.0)            # 4s-5.5s
 "))
-        (qvm (qvm::make-pulse-tracing-qvm 100))) ; TODO should we bake in a default sample rate here?
+        ;; The frames here are pure nonsense.
+        (qvm (qvm::make-pulse-tracing-qvm (list (cons (quil:frame (list (quil:qubit 0)) "xy")
+                                                      (qvm::make-frame-state :frequency 100000 :sample-rate 50000))
+                                                (cons (quil:frame (list (quil:qubit 1)) "xy")
+                                                      (qvm::make-frame-state :frequency 100000 :sample-rate 50000))
+                                                (cons (quil:frame (list (quil:qubit 1)) "rx")
+                                                      (qvm::make-frame-state :frequency 400000 :sample-rate 50000))
+                                                (cons (quil:frame (mapcar #'quil:qubit '(0 1)) "foo")
+                                                      (qvm::make-frame-state :frequency 800000 :sample-rate 50000))))))
     (load-program qvm pp)
     (run qvm)
     ;; check frame state
@@ -29,3 +37,27 @@ PULSE 0 1 \"foo\" flat(duration: 1.5, iq: 1.0)            # 4s-5.5s
         (is (= 4.0 (qvm::pulse-event-start-time event)))
         (is (= 5.5 (qvm::pulse-event-end-time event)))
         (is (= 1.5 (qvm::pulse-event-duration event)))))))
+
+
+(deftest test-pulse-tracing-illegal-frame ()
+    (let ((pp (quil:parse-quil "
+SET-FREQUENCY 0 \"xy\" 1e9
+SET-PHASE 0 \"xy\" 0.5
+PULSE 0 \"xy\" gaussian(duration: 1.0, fwhm: 2, t0: 3)    # 0s-1s
+FENCE 0 1
+PULSE 1 \"xy\" gaussian(duration: 1.0, fwhm: 2, t0: 3)    # 1s-2s
+DECLARE ro BIT[100]
+RAW-CAPTURE 1 \"rx\" 2.0 ro                               # 2s-4s
+PULSE 0 1 \"foo\" flat(duration: 1.5, iq: 1.0)            # 4s-5.5s
+"))
+          (qvm (qvm::make-pulse-tracing-qvm (list (cons (quil:frame (list (quil:qubit 1)) "xy")
+                                                        (qvm::make-frame-state :frequency 100000 :sample-rate 50000))
+                                                  (cons (quil:frame (list (quil:qubit 1)) "rx")
+                                                        (qvm::make-frame-state :frequency 400000 :sample-rate 50000))
+                                                  (cons (quil:frame (mapcar #'quil:qubit '(0 1)) "foo")
+                                                        (qvm::make-frame-state :frequency 800000 :sample-rate 50000))))))
+      (load-program qvm pp)
+      ;; Execution fails on the first pulse, since we haven't told the QVM about
+      ;; the presence of an "xy" frame on qubit 0.
+      (signals error
+        (run qvm))))

--- a/tests/pulse-tracing-qvm-tests.lisp
+++ b/tests/pulse-tracing-qvm-tests.lisp
@@ -23,7 +23,7 @@ SET-PHASE 0 \"xy\" 0.5
 PULSE 0 \"xy\" gaussian(duration: 1.0, fwhm: 2, t0: 3)    # 0s-1s
 FENCE 0 1
 PULSE 1 \"xy\" gaussian(duration: 1.0, fwhm: 2, t0: 3)    # 1s-2s
-DECLARE ro BIT[100]
+DECLARE ro REAL[100]
 RAW-CAPTURE 1 \"rx\" 2.0 ro                               # 2s-4s
 PULSE 0 1 \"foo\" flat(duration: 1.5, iq: 1.0)            # 4s-5.5s
 "))

--- a/tests/pulse-tracing-qvm-tests.lisp
+++ b/tests/pulse-tracing-qvm-tests.lisp
@@ -3,6 +3,21 @@
 ;;; TODO: export symbols from QVM
 (deftest test-tracing-simple-quilt-program ()
   (let ((pp (quil:parse-quil "
+DEFFRAME 0 \"xy\":
+    SAMPLE-RATE: 1.0
+
+DEFFRAME 1 \"xy\":
+    SAMPLE-RATE: 1.0
+    INITIAL-FREQUENCY: 1e9
+
+DEFFRAME 0 1 \"foo\":
+    SAMPLE-RATE: 1.0
+    INITIAL-FREQUENCY: 1e9
+
+DEFFRAME 1 \"rx\":
+    SAMPLE-RATE: 1.0
+    INITIAL-FREQUENCY: 1e9
+
 SET-FREQUENCY 0 \"xy\" 1e9
 SET-PHASE 0 \"xy\" 0.5
 PULSE 0 \"xy\" gaussian(duration: 1.0, fwhm: 2, t0: 3)    # 0s-1s
@@ -13,14 +28,8 @@ RAW-CAPTURE 1 \"rx\" 2.0 ro                               # 2s-4s
 PULSE 0 1 \"foo\" flat(duration: 1.5, iq: 1.0)            # 4s-5.5s
 "))
         ;; The frames here are pure nonsense.
-        (qvm (qvm::make-pulse-tracing-qvm (list (cons (quil:frame (list (quil:qubit 0)) "xy")
-                                                      (qvm::make-frame-state :frequency 100000 :sample-rate 50000))
-                                                (cons (quil:frame (list (quil:qubit 1)) "xy")
-                                                      (qvm::make-frame-state :frequency 100000 :sample-rate 50000))
-                                                (cons (quil:frame (list (quil:qubit 1)) "rx")
-                                                      (qvm::make-frame-state :frequency 400000 :sample-rate 50000))
-                                                (cons (quil:frame (mapcar #'quil:qubit '(0 1)) "foo")
-                                                      (qvm::make-frame-state :frequency 800000 :sample-rate 50000))))))
+        (qvm (qvm::make-pulse-tracing-qvm)))
+    (qvm::initialize-frame-states qvm (quil:parsed-program-frame-definitions pp))
     (load-program qvm pp)
     (run qvm)
     ;; check frame state
@@ -37,27 +46,3 @@ PULSE 0 1 \"foo\" flat(duration: 1.5, iq: 1.0)            # 4s-5.5s
         (is (= 4.0 (qvm::pulse-event-start-time event)))
         (is (= 5.5 (qvm::pulse-event-end-time event)))
         (is (= 1.5 (qvm::pulse-event-duration event)))))))
-
-
-(deftest test-pulse-tracing-illegal-frame ()
-    (let ((pp (quil:parse-quil "
-SET-FREQUENCY 0 \"xy\" 1e9
-SET-PHASE 0 \"xy\" 0.5
-PULSE 0 \"xy\" gaussian(duration: 1.0, fwhm: 2, t0: 3)    # 0s-1s
-FENCE 0 1
-PULSE 1 \"xy\" gaussian(duration: 1.0, fwhm: 2, t0: 3)    # 1s-2s
-DECLARE ro BIT[100]
-RAW-CAPTURE 1 \"rx\" 2.0 ro                               # 2s-4s
-PULSE 0 1 \"foo\" flat(duration: 1.5, iq: 1.0)            # 4s-5.5s
-"))
-          (qvm (qvm::make-pulse-tracing-qvm (list (cons (quil:frame (list (quil:qubit 1)) "xy")
-                                                        (qvm::make-frame-state :frequency 100000 :sample-rate 50000))
-                                                  (cons (quil:frame (list (quil:qubit 1)) "rx")
-                                                        (qvm::make-frame-state :frequency 400000 :sample-rate 50000))
-                                                  (cons (quil:frame (mapcar #'quil:qubit '(0 1)) "foo")
-                                                        (qvm::make-frame-state :frequency 800000 :sample-rate 50000))))))
-      (load-program qvm pp)
-      ;; Execution fails on the first pulse, since we haven't told the QVM about
-      ;; the presence of an "xy" frame on qubit 0.
-      (signals error
-        (run qvm))))

--- a/tests/pulse-tracing-qvm-tests.lisp
+++ b/tests/pulse-tracing-qvm-tests.lisp
@@ -46,3 +46,20 @@ PULSE 0 1 \"foo\" flat(duration: 1.5, iq: 1.0)            # 4s-5.5s
         (is (= 4.0 (qvm::pulse-event-start-time event)))
         (is (= 5.5 (qvm::pulse-event-end-time event)))
         (is (= 1.5 (qvm::pulse-event-duration event)))))))
+
+(deftest test-tracing-quilt-nonblocking ()
+  (let* ((pp (quil:parse-quil "
+DEFFRAME 0 \"xy\":
+    SAMPLE-RATE: 1.0
+    INITIAL-FREQUENCY: 1e9
+
+DEFFRAME 0 \"foo\":
+    SAMPLE-RATE: 1.0
+    INITIAL-FREQUENCY: 1e9
+
+NONBLOCKING PULSE 0 \"xy\" gaussian(duration: 1.0, fwhm: 2, t0: 3)
+PULSE 0 \"foo\" gaussian(duration: 1.5, fwhm: 2, t0: 3)
+PULSE 0 \"xy\" gaussian(duration: 1.0, fwhm: 2, t0: 3)"))
+         (log (qvm::trace-quilt-program pp)))
+    (is (equalp '(0.0 0.0 1.5)
+                (map 'list #'qvm::pulse-event-start-time log)))))


### PR DESCRIPTION
This is work done in parallel with https://github.com/rigetti/quilc/pull/377, and in particular will not be functional without that code active in your local quicklisp.

The main feature here is simply transitioning on _simple quilt_ instructions (namely, basic non-control flow pulse and frame operations). 