### PR TITLE
use updated magicl/core

### DIFF
--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -192,10 +192,6 @@
   #+sbcl
   (format t "Loaded libraries:~%~{  ~A~%~}~%"
           (mapcar 'sb-alien::shared-object-pathname sb-sys:*shared-objects*))
-  ;; (unless (magicl.foreign-libraries:foreign-symbol-available-p "zuncsd_"
-  ;;                                                              'magicl.foreign-libraries:liblapack)
-  ;;   (format t "The loaded version of LAPACK is missing necessary functionality.~%")
-  ;;   (quit-nicely 1))
   (format t "Library check passed.~%")
   (quit-nicely 0))
 

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -192,10 +192,10 @@
   #+sbcl
   (format t "Loaded libraries:~%~{  ~A~%~}~%"
           (mapcar 'sb-alien::shared-object-pathname sb-sys:*shared-objects*))
-  (unless (magicl.foreign-libraries:foreign-symbol-available-p "zuncsd_"
-                                                               'magicl.foreign-libraries:liblapack)
-    (format t "The loaded version of LAPACK is missing necessary functionality.~%")
-    (quit-nicely 1))
+  ;; (unless (magicl.foreign-libraries:foreign-symbol-available-p "zuncsd_"
+  ;;                                                              'magicl.foreign-libraries:liblapack)
+  ;;   (format t "The loaded version of LAPACK is missing necessary functionality.~%")
+  ;;   (quit-nicely 1))
   (format t "Library check passed.~%")
   (quit-nicely 0))
 

--- a/qvm.asd
+++ b/qvm.asd
@@ -18,7 +18,7 @@
                ;; Parallelization utilities
                #:lparallel
                ;; Matrix algebra
-               (:version #:magicl "0.7.0")
+               #:magicl/core
                ;; weak hash tables
                #:trivial-garbage
                ;; static globals
@@ -30,7 +30,7 @@
                ;; Finalizers and portable GC calls
                #:trivial-garbage
                ;; Quil parsing and analysis
-               (:version #:cl-quil "1.17.0")
+               #:cl-quil
                ;; Portable random number generator
                #:mt19937
                ;; For allocation info.


### PR DESCRIPTION
See also quil-lang/magicl#137

This drops the magicl dependency to magicl/core, which contains pure lisp code.

We need to in some manner allow for easy detection or configuration of whether liblapack should be used. For most people it should be, but occasionally we don't want it. With the current changes, users will have to explicitly load it.