### PR TITLE
lower default QVM operator cache limit, add caching to executable

### DIFF
--- a/app/src/build-configuration.lisp
+++ b/app/src/build-configuration.lisp
@@ -1,0 +1,18 @@
+;;;; build-configuration.lisp
+;;;;
+;;;; Author: Robert Smith
+
+(in-package #:qvm)
+
+;;; This file contains configuration of the QVM package for use with
+;;; the executable.
+;;;
+;;; In general, one would see changes to 'config.lisp' constants here.
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (format t "~&Warming the operator cache for ~D qubit~:P..."
+          #1=*executable-time-operator-cache-limit*)
+  (finish-output)
+  (warm-apply-matrix-operator-cache :max-qubits #1#)
+  (format t "done~%")
+  (finish-output))

--- a/build-app.lisp
+++ b/build-app.lisp
@@ -36,6 +36,7 @@
     (load-systems-table)
     (push #'local-system-search asdf:*system-definition-search-functions*)
     (asdf:load-system "qvm-app")
+    (load "app/src/build-configuration.lisp")
     (funcall (read-from-string "qvm-app::setup-debugger"))
     (when (find "--qvm-sdk" sb-ext:*posix-argv* :test 'string=)
       (load "app/src/mangle-shared-objects.lisp"))

--- a/src/apply-gate.lisp
+++ b/src/apply-gate.lisp
@@ -11,7 +11,7 @@
 
 ;;; Warm the cache at compile time.
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (warm-apply-matrix-operator-cache :max-qubits 30))
+  (warm-apply-matrix-operator-cache :max-qubits *compile-time-operator-cache-limit*))
 
 (defun %evolve-pure-state-stochastically (kraus-map state qubits)
   " Uniformly at random select one of the kraus operators in KRAUS-MAP to apply for the PURE-STATE STATE. Randomly select one of the Kraus operators by inverse transform sampling (cf [1]): We divide the unit interval [0,1] into n bins where the j-th bin size equals the probability p_j with which the j-th Kraus operator k_j should be applied. We know that the Kraus operators are normalized such that p_j = <psi|k_j^H k_j |psi> where x^H denotes hermitian conjugation of x and can therefore perform this sampling lazily: 

--- a/src/compile-gate.lisp
+++ b/src/compile-gate.lisp
@@ -311,6 +311,7 @@ QUBITS should be a NAT-TUPLE of qubits representing the Hilbert space."
 
 ;;;;;;;;;;;;;;;;;;;;;;; APPLY OPERATOR CACHING ;;;;;;;;;;;;;;;;;;;;;;;
 
+;;; For debugging, reset this with CLRHASH.
 (global-vars:define-global-var **apply-matrix-operator-functions**
     (make-hash-table :test 'equal)
   "A table mapping lists of qubit indexes representing Hilbert spaces to their compiled gate application functions.

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -25,6 +25,16 @@ See also *QUBIT-LIMIT-FOR-USING-SERIAL-KERNELS*.")
   (max *qubit-limit-for-using-serial-kernels*
        *qubits-required-for-parallelization*))
 
+(defvar *compile-time-operator-cache-limit* 8
+  "At compile time, a cache of optimized \"matrix application\" operators are computed. Further ones will be cached at runtime. This configuration parameter controls how many qubits this cache is warmed for.
+
+This parameter should be optimized for developer convenience.")
+
+(defvar *executable-time-operator-cache-limit* 30
+  "Like *COMPILE-TIME-OPERATOR-CACHE-LIMIT*, but the amount of cache to warm before an executable is created. (There is no guarantee executable creation software will respect this suggested parameter.)
+
+This parameter should be optimized for end-user convenience.")
+
 (defvar *transition-verbose* nil
   "Controls whether each transition is printed with a timing.")
 


### PR DESCRIPTION
This PR decreases the amount of cache warming when the QVM system is compiled to just 8 qubits, which takes around 1.5 seconds on my old laptop on battery. However, when the executable is built, we cache for up to 30 qubits.