### PR TITLE
Handle finicky corner case of deterministic measurements

### DIFF
--- a/src/measurement.lisp
+++ b/src/measurement.lisp
@@ -90,11 +90,15 @@
           "Trying to measure qubit ~D on a QVM with only ~D qubit~:P."
           q
           (number-of-qubits qvm))
-  (let* ((r (random 1.0d0))
-         (excited-probability (get-excited-state-probability (state qvm) q))
-         (cbit (if (<= r excited-probability)
-                   1
-                   0)))
+  (let* ((excited-probability (get-excited-state-probability (state qvm) q))
+         ;; If we had access to truly uniform random variables, the
+         ;; standard "inverse transform sampling" would be enough
+         ;; here. But due to finite precision we force an extra
+         ;; consideration: measurements with probability zero or one
+         ;; should be deterministic.
+         (cbit (cond ((zerop excited-probability) 0)
+                     ((<= (random 1d0) excited-probability) 1)
+                     (t 0))))
     ;; Force the non-deterministic measurement.
     (force-measurement cbit q (state qvm) excited-probability)
     ;; Return the qvm.


### PR DESCRIPTION
This addresses #277 

The approach used for generating Bernoulli random variables is "inverse transform sampling", which would work fine if `(random 1d0)` was "truly" uniform. Since we have only 53 bits of precision, even a perfect implementation of `(random 1d0)` would give a (1/2)^53 chance of producing a `0`. On that fateful day, when the planets align and the birds by sheer coincidence begin singing in unison, some poor sob will run a deterministic circuit and get back just the opposite of what was expected. But nobody will have told our unsuspecting QC enthusiast that it was, in fact, Opposite Day.

This is an easy fix at least. With the current method of `<=` comparison we just handle the zero probability case explicitly. We end up with two conditions met:
1. preserve the general statistical behavior of `measure`
2. enforce deterministic outcomes for events of probability 0 or 1

Note that we're really just hiding the quantization issues elsewhere (which are now felt in the difference between `excited-probability` being 0 vs the next largest double float), but this provides (2) at no real expense to (1).