### PR TITLE
use cl-quil/frontend

### DIFF
--- a/qvm-app.asd
+++ b/qvm-app.asd
@@ -9,7 +9,7 @@
   :version (:read-file-form "VERSION.txt")
   :depends-on (
                ;; Quil parsing
-               (:version #:cl-quil "1.17.0")
+               (:version #:cl-quil/frontend "1.26.0")
                ;; Command line argument parsing
                #:command-line-arguments
                ;; ASDF-companion utility library

--- a/qvm-tests.asd
+++ b/qvm-tests.asd
@@ -6,7 +6,7 @@
   :description "Regression tests for the QVM."
   :author "Robert Smith <robert@rigetti.com>"
   :license "Apache License 2.0 (See LICENSE.txt)"
-  :depends-on (#:cl-quil
+  :depends-on (#:cl-quil/frontend
                #:qvm
                #:qvm-examples
                #:alexandria

--- a/qvm.asd
+++ b/qvm.asd
@@ -30,7 +30,7 @@
                ;; Finalizers and portable GC calls
                #:trivial-garbage
                ;; Quil parsing and analysis
-               (:version #:cl-quil "1.17.0")
+               (:version #:cl-quil/frontend "1.26.0")
                ;; Portable random number generator
                #:mt19937
                ;; For allocation info.

--- a/src/channel-qvm.lisp
+++ b/src/channel-qvm.lisp
@@ -201,8 +201,8 @@
     (check-type p01 (double-float 0.0d0 1.0d0))
     (check-type p10 (double-float 0.0d0 1.0d0))
     (check-type p11 (double-float 0.0d0 1.0d0))
-    (assert (cl-quil::double= 1.0d0 (+ p00 p10)))
-    (assert (cl-quil::double= 1.0d0 (+ p01 p11)))))
+    (assert (quil::double= 1.0d0 (+ p00 p10)))
+    (assert (quil::double= 1.0d0 (+ p01 p11)))))
 
 (defun check-all-povms (seq)
   "Call CHECK-POVM on each element of SEQ."

--- a/src/compile-gate.lisp
+++ b/src/compile-gate.lisp
@@ -541,11 +541,11 @@ If the gate can't be compiled, return (VALUES NIL NIL).")
             :documentation "A list of qubit-mref pairs to store, in order."))
   (:documentation "A pseudo-instruction for measuring all qubits simultaneously."))
 
-(defmethod cl-quil::%max-qubit ((isn measure-all))
+(defmethod quil::%max-qubit ((isn measure-all))
   (loop :for qubit-mref :in (measure-all-storage isn)
         :maximize (car qubit-mref)))
 
-(defmethod cl-quil::print-instruction-generic ((instr measure-all) stream)
+(defmethod quil::print-instruction-generic ((instr measure-all) stream)
   (format stream "{ MEASURE-ALL to ~D location~:P }"
           (length (measure-all-storage instr))))
 

--- a/src/depolarizing-noise.lisp
+++ b/src/depolarizing-noise.lisp
@@ -70,9 +70,9 @@ It should be that PX + PY + PZ <= 1.
           (return-from add-depolarizing-noise))))))
 
 ;;; Noise gets added to only the qubits being changed.
-(defmethod transition :after ((qvm depolarizing-qvm) (instr cl-quil:application))
-  (dolist (arg (cl-quil:application-arguments instr))
-    (when (typep arg 'cl-quil:qubit)
+(defmethod transition :after ((qvm depolarizing-qvm) (instr quil:application))
+  (dolist (arg (quil:application-arguments instr))
+    (when (typep arg 'quil:qubit)
       (let ((instr-qubits (quil:qubit-index arg)))
         (add-depolarizing-noise qvm (list instr-qubits)
                                 (probability-gate-x qvm)
@@ -80,7 +80,7 @@ It should be that PX + PY + PZ <= 1.
                                 (probability-gate-z qvm))))))
 
 ;;; Noise gets added to every qubit after a RESET.
-(defmethod transition :after ((qvm depolarizing-qvm) (instr cl-quil:reset))
+(defmethod transition :after ((qvm depolarizing-qvm) (instr quil:reset))
   (declare (ignore instr))
   (dotimes (q (number-of-qubits qvm))
     (add-depolarizing-noise qvm (list q)
@@ -90,8 +90,8 @@ It should be that PX + PY + PZ <= 1.
 
 ;;; Noise gets added to only the qubit being measured, before
 ;;; measurement occurs.
-(defmethod transition :before ((qvm depolarizing-qvm) (instr cl-quil:measurement))
-  (let ((q (cl-quil:qubit-index (cl-quil:measurement-qubit instr))))
+(defmethod transition :before ((qvm depolarizing-qvm) (instr quil:measurement))
+  (let ((q (quil:qubit-index (quil:measurement-qubit instr))))
     (add-depolarizing-noise qvm (list q)
                             (probability-measure-x qvm)
                             (probability-measure-y qvm)

--- a/src/noise-models.lisp
+++ b/src/noise-models.lisp
@@ -237,14 +237,14 @@
   (lambda (instr)
     (and (typep instr 'quil:gate-application)
          (quil::plain-operator-p (quil:application-operator instr))
-         (string= gate (cl-quil::application-operator-root-name instr)))))
+         (string= gate (quil::application-operator-root-name instr)))))
 
 (defun match-any-gates (&rest gates)
   "The returned function is true if there is any intersection between the instruction's gate and GATES."
   (lambda (instr)
     (and (typep instr 'quil:gate-application)
          (quil::plain-operator-p (quil:application-operator instr))
-         (member (cl-quil::application-operator-root-name instr) gates :test #'string=))))
+         (member (quil::application-operator-root-name instr) gates :test #'string=))))
 
 (defun match-all-nq-gates (n)
   "The returned function is true if the instruction operates on N qubits."
@@ -277,4 +277,4 @@
 (defun match-instr-idxs (parsed-prog &rest idxs)
   "The returned function is true if the index of the INSTR in the program PARSED-PROG matches IDXS."
   (lambda (instr)
-    (member (position instr (cl-quil::parsed-program-executable-code parsed-prog) :test 'eq) idxs)))
+    (member (position instr (quil::parsed-program-executable-code parsed-prog) :test 'eq) idxs)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -10,6 +10,9 @@
   (:shadowing-import-from #:mt19937
                           #:random)
 
+  #+(or sbcl ecl ccl)
+  (:local-nicknames (:quil :cl-quil.frontend))
+
   ;; config.lisp
   (:export
    #:parallelization-limit              ; TYPE

--- a/src/stabilizer-qvm.lisp
+++ b/src/stabilizer-qvm.lisp
@@ -127,7 +127,7 @@
   (:documentation "A gate application that's actually a Clifford."))
 
 (defmethod quil::print-instruction-generic ((instr clifford-application) stream)
-  (format stream "<clifford>~{ ~/cl-quil:instruction-fmt/~}"
+  (format stream "<clifford>~{ ~/quil:instruction-fmt/~}"
           (quil:application-arguments instr)))
 
 (defmethod print-object ((o clifford-application) stream)

--- a/src/transition.lisp
+++ b/src/transition.lisp
@@ -36,7 +36,7 @@ Return just the resulting (possibly modified) QVM after executing INSTR. (Histor
            gc-time bytes-alloc)
        (multiple-value-prog1 (measuring-gc (gc-time bytes-alloc) (call-next-method))
          (format *trace-output* "~&; Transition ~A took ~D ms (gc: ~D ms; alloc: ~D bytes)~%"
-                 (with-output-to-string (s) (cl-quil:print-instruction instr s))
+                 (with-output-to-string (s) (quil:print-instruction instr s))
                  (round (* (/ 1000 internal-time-units-per-second)
                            (- (get-internal-real-time) start)))
                  gc-time

--- a/tests/channel-qvm-tests.lisp
+++ b/tests/channel-qvm-tests.lisp
@@ -73,8 +73,8 @@
          (rule-1-match (qvm::find-matching-rule rules test-gate-1 posn))
          (rule-2-match (qvm::find-matching-rule rules test-gate-2 posn)))
     ;; Check that the kraus operators returned (gate-x-match) are correct.
-    (is (every #'cl-quil::matrix-equality (first (qvm::operation-elements rule-1-match)) kraus1))
-    (is (every #'cl-quil::matrix-equality (first (qvm::operation-elements rule-2-match)) kraus2))
+    (is (every #'quil::matrix-equality (first (qvm::operation-elements rule-1-match)) kraus1))
+    (is (every #'quil::matrix-equality (first (qvm::operation-elements rule-2-match)) kraus2))
     (is (qvm::find-matching-rule rules test-gate-2 posn))
     (is (not (qvm::find-matching-rule rules test-gate-3 posn)))))
 
@@ -193,14 +193,14 @@
 
 (defun noisy-program-strings (parsed-program qvm)
   "Return a list of strings representing a noisy program. The returned list consists of the original program instructions as strings interjected with the NOISE-PRED NAMEs of the NOISE-RULES in the QVM's NOISE-MODEL."
-  (let ((parsed-instructions (cl-quil::parsed-program-executable-code parsed-program))
+  (let ((parsed-instructions (quil::parsed-program-executable-code parsed-program))
         (rules (qvm::noise-rules (qvm::noise-model qvm))))
     (loop :for instr :across parsed-instructions
           :for rule-before-instr := (qvm::find-matching-rule rules instr :before)
           :for rule-after-instr := (qvm:: find-matching-rule rules instr :after)
           :when rule-before-instr
             :collect (qvm::name (qvm::noise-predicate rule-before-instr))
-          :collect (cl-quil::print-instruction-to-string instr)
+          :collect (quil::print-instruction-to-string instr)
           :when rule-after-instr
             :collect (qvm::name (qvm::noise-predicate rule-after-instr)))))
 

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -4,6 +4,8 @@
 
 (fiasco:define-test-package #:qvm-tests
   (:use #:qvm)
+  #+(or sbcl ecl ccl)
+  (:local-nicknames (:quil :cl-quil.frontend))
   
   ;; suite.lisp
   (:export


### PR DESCRIPTION
cf. https://github.com/quil-lang/quilc/pull/761

We make some tweaks so that the `qvm` relies only on `cl-quil/frontend`. One convenient but possibly questionable choice is that we alias the package `cl-quil.frontend` to `quil`, since it's annoying to not do so.