### PR TITLE
drop expokit dependency

### DIFF
--- a/qvm.asd
+++ b/qvm.asd
@@ -18,7 +18,8 @@
                ;; Parallelization utilities
                #:lparallel
                ;; Matrix algebra
-               (:version #:magicl "0.7.0")
+               (:version #:magicl/core "0.9.0")
+               #:magicl/ext-lapack
                ;; weak hash tables
                #:trivial-garbage
                ;; static globals


### PR DESCRIPTION
The full magicl suite includes expokit, but we don't need it, and so should just drop it. Also, with the recent qvm-in-cl-quil work, this expokit stuff would also be required by cl-quil. This appears to be the cause of tests failing on https://github.com/quil-lang/quilc/pull/779