### PR TITLE
Make QVM-INTRINSICS work again.

### DIFF
--- a/app-ng/src/entry-point.lisp
+++ b/app-ng/src/entry-point.lisp
@@ -105,7 +105,7 @@ Copyright (c) 2016-2019 Rigetti Computing.~2%")
           (list                         ; List of features
                 #+qvm-intrinsics
                 "qvm-intrinsics"
-                #+(and qvm-intrinsics avx2)
+                #+qvm-avx2
                 "avx2")))
     (format *error-output* "(Features enabled: ~{~a~^, ~})~2%"
             (or qvm-features (list "none"))))

--- a/app/src/entry-point.lisp
+++ b/app/src/entry-point.lisp
@@ -223,11 +223,12 @@ Copyright (c) 2016-2019 Rigetti Computing.~2%")
           (length qvm::*available-kernels*)
           (qvm::qubit-limit-for-using-serial-kernels))
   (let ((qvm-features
-          (list                         ; List of features
-                #+qvm-intrinsics
-                "qvm-intrinsics"
-                #+(and qvm-intrinsics avx2)
-                "avx2")))
+          (list
+           ;; List of features
+           #+qvm-intrinsics
+           "qvm-intrinsics"
+           #+qvm-avx2
+           "avx2")))
     (format t "(Features enabled: ~{~a~^, ~})~2%"
             (or qvm-features (list "none"))))
   nil)

--- a/qvm.asd
+++ b/qvm.asd
@@ -2,6 +2,11 @@
 ;;;;
 ;;;; Author: Robert Smith
 
+#+sbcl
+#.(when (sb-alien:extern-alien "avx2_supported" sb-alien:int)
+    (cl:push :qvm-avx2 cl:*features*)
+    (values))
+
 (asdf:defsystem #:qvm
   :description "An implementation of the Quantum Abstract Machine."
   :author "Robert Smith <robert@rigetti.com>"
@@ -52,7 +57,8 @@
                (:file "impl/clozure" :if-feature :clozure)
                (:file "impl/sbcl" :if-feature :sbcl)
                (:file "impl/sbcl-intrinsics" :if-feature (:and :sbcl :qvm-intrinsics))
-               (:file "impl/sbcl-avx-vops" :if-feature (:and :sbcl :qvm-intrinsics :avx2))
+               (:file "impl/sbcl-avx-vops"
+                :if-feature (:and :sbcl :qvm-intrinsics :qvm-avx2))
                (:file "impl/sbcl-x86-vops" :if-feature (:and :sbcl :qvm-intrinsics))
                (:file "impl/linear-algebra-intrinsics" :if-feature :qvm-intrinsics)
                (:file "impl/prefetch-intrinsics" :if-feature :qvm-intrinsics)

--- a/src/impl/sbcl-x86-vops.lisp
+++ b/src/impl/sbcl-x86-vops.lisp
@@ -36,10 +36,5 @@
   (:results)
   (:info type disp stride)
   (:generator 1
-              (inst prefetch type
-                    (make-ea :byte :base base
-                                   :index index
-                                   :scale (ash stride
-                                               (- n-fixnum-tag-bits))
-                                   :disp disp))))
+    (inst prefetch type (ea disp base index (ash stride (- n-fixnum-tag-bits))))))
 

--- a/src/serial-kernels.lisp
+++ b/src/serial-kernels.lisp
@@ -170,10 +170,10 @@ Note: This function is raw and unsafe. Pass bad data => get a crash."
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; One Qubit ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-#-(and qvm-intrinsics avx2)
+#-(and qvm-intrinsics qvm-avx2)
 (define-serial-kernel apply-1q-operator 1)
 
-#+(and qvm-intrinsics avx2)
+#+(and qvm-intrinsics qvm-avx2)
 (defun apply-1q-operator (operator wavefunction q)
   "Apply the matrix operator OPERATOR to the amplitudes of WAVEFUNCTION specified by the qubit Q."
   (declare (inline qvm-intrinsics::2x2matrix-to-simd
@@ -204,10 +204,10 @@ Note: This function is raw and unsafe. Pass bad data => get a crash."
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Two Qubits ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-#-(and qvm-intrinsics avx2)
+#-(and qvm-intrinsics qvm-avx2)
 (define-serial-kernel apply-2q-operator 2)
 
-#+(and qvm-intrinsics avx2)
+#+(and qvm-intrinsics qvm-avx2)
 (defun apply-2q-operator (operator wavefunction q0 q1)
   "Apply the matrix operator OPERATOR to the amplitudes of WAVEFUNCTION specified by the qubits Q0 and Q1."
   (declare (inline qvm-intrinsics::2x4matrix-to-simd

--- a/src/wavefunction.lisp
+++ b/src/wavefunction.lisp
@@ -319,7 +319,7 @@ up to amplitude ordering."
        (apply kernel matrix wavefunction (coerce qubits 'list)))
       ;; Call the 1q or 2q kernel in the case of intrinsics, in which
       ;; case parallelization will work.
-      #+(and qvm-intrinsics avx2)
+      #+(and qvm-intrinsics qvm-avx2)
       ((and kernel (or (= k 1) (= k 2)))
        (apply kernel matrix wavefunction (coerce qubits 'list)))
       (t


### PR DESCRIPTION
* Change MAKE-EA to EA.
* Test for AVX2 in a different way, as we're not allowed to test sbcl
internal features anymore.