### PR TITLE
add depolarizing stabilizer QVM and error-only QVM

### DIFF
--- a/qvm-tests.asd
+++ b/qvm-tests.asd
@@ -42,4 +42,5 @@
                (:file "basic-noise-qvm-tests")
                (:file "unitary-tests")
                (:file "parallel-tests")
-               (:file "qvm-avx-intrinsics" :if-feature (:and :qvm-intrinsics :avx2))))
+               (:file "qvm-avx-intrinsics" :if-feature (:and :qvm-intrinsics :avx2))
+               (:file "error-qvm-tests")))

--- a/qvm.asd
+++ b/qvm.asd
@@ -92,4 +92,9 @@
                (:file "density-qvm")
                (:file "noisy-qvm")
                (:file "depolarizing-noise")
-               (:file "unitary-qvm")))
+               (:file "unitary-qvm")
+               (:module "error"
+                :serial t
+                :components ((:file "package")
+                             (:file "fowler-noise")
+                             (:file "error-qvm")))))

--- a/src/depolarizing-noise.lisp
+++ b/src/depolarizing-noise.lisp
@@ -30,12 +30,12 @@
     :accessor probability-measure-z
     :documentation "Probability of a Pauli Z gate happening before a measurement."))
   (:documentation "A quantum virtual machine with parametric depolarizing noise.")
-  (:default-initargs :x 0d0
-                     :y 0d0
-                     :z 0d0
-                     :measure-x 0d0
-                     :measure-y 0d0
-                     :measure-z 0d0))
+  (:default-initargs :x 0.0d0
+                     :y 0.0d0
+                     :z 0.0d0
+                     :measure-x 0.0d0
+                     :measure-y 0.0d0
+                     :measure-z 0.0d0))
 
 (defgeneric add-depolarizing-noise (qvm qubits px py pz)
   (:documentation
@@ -56,7 +56,7 @@ It should be that PX + PY + PZ <= 1.")
         (setf px (/ px sum)
               py (/ py sum)
               pz (/ pz sum))
-        (let ((r (random 1.0))
+        (let ((r (random 1.0d0))
               (pure-state (state qvm)))
           (when (< r px)
             (apply-gate-to-state X pure-state qubits)
@@ -132,12 +132,12 @@ It should be that PX + PY + PZ <= 1.")
     :accessor probability-measure-z
     :documentation "Probability of a Pauli Z gate happening before a measurement."))
   (:documentation "A quantum virtual machine with parametric depolarizing noise.")
-  (:default-initargs :x 0.0
-                     :y 0.0
-                     :z 0.0
-                     :measure-x 0.0
-                     :measure-y 0.0
-                     :measure-z 0.0))
+  (:default-initargs :x 0.0d0
+                     :y 0.0d0
+                     :z 0.0d0
+                     :measure-x 0.0d0
+                     :measure-y 0.0d0
+                     :measure-z 0.0d0))
 
 (defmethod transition :after ((qvm depolarizing-stabilizer-qvm) (instr cl-quil:application))
   (dolist (arg (cl-quil:application-arguments instr))
@@ -181,7 +181,7 @@ It should be that PX + PY + PZ <= 1.")
         (setf px (/ px sum)
               py (/ py sum)
               pz (/ pz sum))
-        (let ((r (random 1.0)))
+        (let ((r (random 1.0d0)))
           (when (< r px)
             (apply-gate X)
             (return-from add-depolarizing-noise))

--- a/src/depolarizing-noise.lisp
+++ b/src/depolarizing-noise.lisp
@@ -30,12 +30,12 @@
     :accessor probability-measure-z
     :documentation "Probability of a Pauli Z gate happening before a measurement."))
   (:documentation "A quantum virtual machine with parametric depolarizing noise.")
-  (:default-initargs :x 0.0
-                     :y 0.0
-                     :z 0.0
-                     :measure-x 0.0
-                     :measure-y 0.0
-                     :measure-z 0.0))
+  (:default-initargs :x 0d0
+                     :y 0d0
+                     :z 0d0
+                     :measure-x 0d0
+                     :measure-y 0d0
+                     :measure-z 0d0))
 
 (defgeneric add-depolarizing-noise (qvm qubits px py pz)
   (:documentation

--- a/src/depolarizing-noise.lisp
+++ b/src/depolarizing-noise.lisp
@@ -37,37 +37,38 @@
                      :measure-y 0.0
                      :measure-z 0.0))
 
-(defun add-depolarizing-noise (qvm qubits px py pz)
-  "Apply depolarizing noise to the list QUBITS of the QVM with the following probabilities:
+(defgeneric add-depolarizing-noise (qvm qubits px py pz)
+  (:documentation
+   "Apply depolarizing noise to the list QUBITS of the QVM with the following probabilities:
 
     * Probability of an X-gate PX,
     * Probability of a Y-gate PY, and
     * Probability of a Z-gate PZ.
 
-It should be that PX + PY + PZ <= 1.
-"
-  (assert (<= (+ px py pz) 1))
-  (let ((X (quil:gate-definition-to-gate (quil:lookup-standard-gate "X")))
-        (Y (quil:gate-definition-to-gate (quil:lookup-standard-gate "Y")))
-        (Z (quil:gate-definition-to-gate (quil:lookup-standard-gate "Z")))
-        (sum (+ px py pz)))
-    (probabilistically sum
-      (setf px (/ px sum)
-            py (/ py sum)
-            pz (/ pz sum))
-      (let ((r (random 1.0))
-            (pure-state (state qvm)))
-        (when (< r px)
-          (apply-gate-to-state X pure-state qubits)
-          (return-from add-depolarizing-noise))
-        (decf r px)
-        (when (< r py)
-          (apply-gate-to-state Y pure-state qubits)
-          (return-from add-depolarizing-noise))
-        (decf r py)
-        (when (< r pz)
-          (apply-gate-to-state Z pure-state qubits)
-          (return-from add-depolarizing-noise))))))
+It should be that PX + PY + PZ <= 1.")
+  (:method ((qvm pure-state-qvm) qubits px py pz)
+    (assert (<= (+ px py pz) 1))
+    (let ((X (quil:gate-definition-to-gate (quil:lookup-standard-gate "X")))
+          (Y (quil:gate-definition-to-gate (quil:lookup-standard-gate "Y")))
+          (Z (quil:gate-definition-to-gate (quil:lookup-standard-gate "Z")))
+          (sum (+ px py pz)))
+      (probabilistically sum
+        (setf px (/ px sum)
+              py (/ py sum)
+              pz (/ pz sum))
+        (let ((r (random 1.0))
+              (pure-state (state qvm)))
+          (when (< r px)
+            (apply-gate-to-state X pure-state qubits)
+            (return-from add-depolarizing-noise))
+          (decf r px)
+          (when (< r py)
+            (apply-gate-to-state Y pure-state qubits)
+            (return-from add-depolarizing-noise))
+          (decf r py)
+          (when (< r pz)
+            (apply-gate-to-state Z pure-state qubits)
+            (return-from add-depolarizing-noise)))))))
 
 ;;; Noise gets added to only the qubits being changed.
 (defmethod transition :after ((qvm depolarizing-qvm) (instr quil:application))
@@ -100,3 +101,95 @@ It should be that PX + PY + PZ <= 1.
 ;;; Don't compile things for the depolarizing-qvm.
 (defmethod compile-loaded-program ((qvm depolarizing-qvm))
   qvm)
+
+;;;
+;;; for want of a better idea, we replicate most of the above for stabilizer QVMs
+;;;
+
+(defclass depolarizing-stabilizer-qvm (stabilizer-qvm)
+  ((probability-gate-x
+    :initarg :x
+    :accessor probability-gate-x
+    :documentation "Probability of a Pauli X gate happening after a gate application or reset.")
+   (probability-gate-y
+    :initarg :y
+    :accessor probability-gate-y
+    :documentation "Probability of a Pauli Y gate happening after a gate application or reset.")
+   (probability-gate-z
+    :initarg :z
+    :accessor probability-gate-z
+    :documentation "Probability of a Pauli Z gate happening after a gate application or reset.")
+   (probability-measure-x
+    :initarg :measure-x
+    :accessor probability-measure-x
+    :documentation "Probability of a Pauli X gate happening before a measurement.")
+   (probability-measure-y
+    :initarg :measure-y
+    :accessor probability-measure-y
+    :documentation "Probability of a Pauli Y gate happening before a measurement.")
+   (probability-measure-z
+    :initarg :measure-z
+    :accessor probability-measure-z
+    :documentation "Probability of a Pauli Z gate happening before a measurement."))
+  (:documentation "A quantum virtual machine with parametric depolarizing noise.")
+  (:default-initargs :x 0.0
+                     :y 0.0
+                     :z 0.0
+                     :measure-x 0.0
+                     :measure-y 0.0
+                     :measure-z 0.0))
+
+(defmethod transition :after ((qvm depolarizing-stabilizer-qvm) (instr cl-quil:application))
+  (dolist (arg (cl-quil:application-arguments instr))
+    (when (typep arg 'cl-quil:qubit)
+      (let ((instr-qubits (quil:qubit-index arg)))
+        (add-depolarizing-noise qvm (list instr-qubits)
+                                (probability-gate-x qvm)
+                                (probability-gate-y qvm)
+                                (probability-gate-z qvm))))))
+
+(defmethod transition :after ((qvm depolarizing-stabilizer-qvm) (instr cl-quil:reset))
+  (declare (ignore instr))
+  (dotimes (q (number-of-qubits qvm))
+    (add-depolarizing-noise qvm (list q)
+                            (probability-gate-x qvm)
+                            (probability-gate-y qvm)
+                            (probability-gate-z qvm))))
+
+(defmethod transition :before ((qvm depolarizing-stabilizer-qvm) (instr cl-quil:measurement))
+  (let ((q (cl-quil:qubit-index (cl-quil:measurement-qubit instr))))
+    (add-depolarizing-noise qvm (list q)
+                            (probability-measure-x qvm)
+                            (probability-measure-y qvm)
+                            (probability-measure-z qvm))))
+
+(defmethod compile-loaded-program ((qvm depolarizing-stabilizer-qvm))
+  qvm)
+
+(defmethod add-depolarizing-noise ((qvm stabilizer-qvm) qubits px py pz)
+  (flet ((apply-gate (instr)
+           (let ((clifford (gate-application-to-clifford instr)))
+             (apply (compile-clifford clifford)
+                    (stabilizer-qvm-tableau qvm)
+                    qubits))))
+    (assert (<= (+ px py pz) 1))
+    (let ((X (apply #'quil::build-gate "X" () qubits))
+          (Y (apply #'quil::build-gate "Y" () qubits))
+          (Z (apply #'quil::build-gate "Z" () qubits))
+          (sum (+ px py pz)))
+      (probabilistically sum
+        (setf px (/ px sum)
+              py (/ py sum)
+              pz (/ pz sum))
+        (let ((r (random 1.0)))
+          (when (< r px)
+            (apply-gate X)
+            (return-from add-depolarizing-noise))
+          (decf r px)
+          (when (< r py)
+            (apply-gate Y)
+            (return-from add-depolarizing-noise))
+          (decf r py)
+          (when (< r pz)
+            (apply-gate Z)
+            (return-from add-depolarizing-noise)))))))

--- a/src/error/README.md
+++ b/src/error/README.md
@@ -1,0 +1,24 @@
+# `qvm.error`
+
+This subpackage implements two classes:
+
+1. `fowler-qvm`: An abstract class which decomposes depolarizing noise into five
+   subchannels which are applied following (1) single-qubit identity gates,
+   (2) non-identity single-qubit gates, (3) two-qubit gates, (4) reset
+   operators, and (5) measurement operators.  These can be selective enabled,
+   permitting one to study the relative effects of these noise sources on
+   measurement circuits commonly found in parity check measurement circuits, as
+   proposed in Section VII.B of [Fowler et al](https://arxiv.org/abs/1208.0928).
+   This class is extended by two subclasses, `fowler-pure-state-qvm` and
+   `fowler-stabilizer-qvm`, which back this noise model by a `pure-state-qvm`
+   and a `stabilizer-qvm` respectively.
+2. `error-qvm`: A separate subclass of `fowler-qvm` backed by "Pauli
+   propagation".  Rather than tracking anything like the full state of a quantum
+   circuit, a Pauli propagation model rather assumes that the circuit being
+   executed is meant to measure stabilizer checks (so, in particular, would
+   return a constant value of "no error" in the absence of noise), injects Pauli
+   flip noise according to some noise model, and tracks how the flips propagate
+   through the circuit to effect an eventual measurement.  This limitation is
+   severe, but it means that the measurement results can be computed in space
+   and time which are _linear_ in the qubit count, a marked improvement over
+   even the stabilizer-/tableau-based QVM.

--- a/src/error/error-qvm.lisp
+++ b/src/error/error-qvm.lisp
@@ -25,7 +25,7 @@
 (defun make-error-qvm (num-qubits
                        &key
                          (classical-memory-model quil::**empty-memory-model**)
-                         (noise-probability 0d0)
+                         (noise-probability 0.0d0)
                          (noise-class 0))
   "Constructs a fresh instance of a specialized QVM which efficiently simulates Pauli error propagation through CNOT-dihedral circuits.
 

--- a/src/error/error-qvm.lisp
+++ b/src/error/error-qvm.lisp
@@ -20,13 +20,16 @@
     :type unsigned-byte
     :reader error-qvm-num-qubits
     :initarg :num-qubits))
-  (:documentation "A QVM that can efficiently the propagation of Pauli errors through gates drawn from the CNOT-dihedral group of order 8."))
+  (:documentation "A noisy QVM that can efficiently the propagation of Pauli errors through gates drawn from the CNOT-dihedral group of order 8.  See FOWLER-QVM for a description of the noise model and parameters."))
 
 (defun make-error-qvm (num-qubits
                        &key
                          (classical-memory-model quil::**empty-memory-model**)
                          (noise-probability 0d0)
                          (noise-class 0))
+  "Constructs a fresh instance of a specialized QVM which efficiently simulates Pauli error propagation through CNOT-dihedral circuits.
+
+See ERROR-QVM for a description of the noise model and noise keyword arguments."
   (check-type num-qubits unsigned-byte)
   (check-type classical-memory-model quil:memory-model)
   (let* ((subsystem (make-instance 'classical-memory-subsystem
@@ -37,8 +40,8 @@
                              :classical-memory-subsystem subsystem
                              :noise-probability noise-probability
                              :noise-class noise-class)))
-    (setf (error-qvm-X-vector qvm) (make-array num-qubits :element-type 'bit)
-          (error-qvm-Z-vector qvm) (make-array num-qubits :element-type 'bit))
+    (setf (error-qvm-X-vector qvm) (make-array num-qubits :element-type 'bit :initial-element 0)
+          (error-qvm-Z-vector qvm) (make-array num-qubits :element-type 'bit :initial-element 0))
     qvm))
 
 (defmethod number-of-qubits ((qvm error-qvm))
@@ -51,8 +54,8 @@
 
 (defmethod transition ((qvm error-qvm) (instr quil:reset))
   (let ((num-qubits (number-of-qubits qvm)))
-    (setf (error-qvm-X-vector qvm) (make-array num-qubits :element-type 'bit)
-          (error-qvm-Z-vector qvm) (make-array num-qubits :element-type 'bit))
+    (setf (error-qvm-X-vector qvm) (make-array num-qubits :element-type 'bit :initial-element 0)
+          (error-qvm-Z-vector qvm) (make-array num-qubits :element-type 'bit :initial-element 0))
     (incf (qvm::pc qvm))
     qvm))
 

--- a/src/error/error-qvm.lisp
+++ b/src/error/error-qvm.lisp
@@ -1,0 +1,142 @@
+;;;; error-qvm.lisp
+;;;;
+;;;; This file implements an efficient QVM which tracks the propagation of Pauli
+;;;; errors through a CNOT-dihedral circuit which, in the absence of errors, is
+;;;; always meant to MEASURE zeroes.  For example, surface code cycles for the
+;;;; usual toric code have this property.
+
+(in-package #:qvm.error)
+
+(defclass error-qvm (fowler-qvm classical-memory-mixin)
+  ((X-vector
+    :accessor error-qvm-X-vector
+    :type simple-bit-vector
+    :documentation "A bit-vector which tracks whether this qubit has experienced an X-error.")
+   (Z-vector
+    :accessor error-qvm-Z-vector
+    :type simple-bit-vector
+    :documentation "A bit-vector which tracks whether this qubit has experienced a Z-error.")
+   (num-qubits
+    :type unsigned-byte
+    :reader error-qvm-num-qubits
+    :initarg :num-qubits))
+  (:documentation "A QVM that can efficiently the propagation of Pauli errors through gates drawn from the CNOT-dihedral group of order 8."))
+
+(defun make-error-qvm (num-qubits
+                       &key
+                         (classical-memory-model quil::**empty-memory-model**)
+                         (noise-probability 0d0)
+                         (noise-class 0))
+  (check-type num-qubits unsigned-byte)
+  (check-type classical-memory-model quil:memory-model)
+  (let* ((subsystem (make-instance 'classical-memory-subsystem
+                                   :classical-memory-model
+                                   classical-memory-model))
+         (qvm (make-instance 'error-qvm
+                             :num-qubits num-qubits
+                             :classical-memory-subsystem subsystem
+                             :noise-probability noise-probability
+                             :noise-class noise-class)))
+    (setf (error-qvm-X-vector qvm) (make-array num-qubits :element-type 'bit)
+          (error-qvm-Z-vector qvm) (make-array num-qubits :element-type 'bit))
+    qvm))
+
+(defmethod number-of-qubits ((qvm error-qvm))
+  (error-qvm-num-qubits qvm))
+
+;;;;;;;;;;;;;;;;;;;;;;;;; TRANSITION Methods ;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod measure ((qvm error-qvm) q)
+  (values qvm (aref (error-qvm-X-vector qvm) q)))
+
+(defmethod transition ((qvm error-qvm) (instr quil:reset))
+  (let ((num-qubits (number-of-qubits qvm)))
+    (setf (error-qvm-X-vector qvm) (make-array num-qubits :element-type 'bit)
+          (error-qvm-Z-vector qvm) (make-array num-qubits :element-type 'bit))
+    (incf (qvm::pc qvm))
+    qvm))
+
+(defmethod transition ((qvm error-qvm) (instr quil:reset-qubit))
+  (let ((index (quil:qubit-index (quil:reset-qubit-target instr))))
+    (setf (aref (error-qvm-X-vector qvm) index) 0
+          (aref (error-qvm-Z-vector qvm) index) 0))
+  (incf (qvm::pc qvm))
+  qvm)
+
+(defmethod transition ((qvm error-qvm) (instr quil:measure))
+  (incf (qvm::pc qvm))
+  (qvm::measure-and-store qvm
+                          (quil:qubit-index (quil:measurement-qubit instr))
+                          (quil:measure-address instr)))
+
+(defmethod transition ((qvm error-qvm) (instr quil:measure-discard))
+  (incf (qvm::pc qvm))
+  (measure qvm (quil:qubit-index (quil:measurement-qubit instr))))
+
+(defmethod transition ((qvm error-qvm) (instr quil:gate-application))
+  (check-type (quil:application-operator instr) quil:named-operator)
+  (adt:with-data (quil:named-operator name) (quil:application-operator instr)
+    (cond
+      ;; intentional toggles do nothing
+      ((or (string= "X" name)
+           (string= "Y" name)
+           (string= "Z" name)
+           (string= "I" name))
+       nil)
+      ;; hadamards trade X and Z
+      ((string= "H" name)
+       (let* ((index (quil:qubit-index (first (quil:application-arguments instr))))
+              (X (aref (error-qvm-X-vector qvm) index))
+              (Z (aref (error-qvm-Z-vector qvm) index)))
+         (setf (aref (error-qvm-X-vector qvm) index) Z
+               (aref (error-qvm-Z-vector qvm) index) X)))
+      ;; CNOTs either transmit or replicate pauli errors.
+      ;; Xs and Zs replicate when present on control and target respectively
+      ((string= "CNOT" name)
+       (let* ((control (quil:qubit-index (first  (quil:application-arguments instr))))
+              (target  (quil:qubit-index (second (quil:application-arguments instr))))
+              (Xc (aref (error-qvm-X-vector qvm) control))
+              (Xt (aref (error-qvm-X-vector qvm) target))
+              (Zc (aref (error-qvm-Z-vector qvm) control))
+              (Zt (aref (error-qvm-Z-vector qvm) target)))
+         (when (plusp Xc)
+           (setf (aref (error-qvm-X-vector qvm) target)
+                 (logxor Xt #b1)))
+         (when (plusp Zt)
+           (setf (aref (error-qvm-Z-vector qvm) control)
+                 (logxor Zc #b1)))))
+      (t
+       (error "Gate ~a is not CNOT-dihedral." instr))))
+  (incf (qvm::pc qvm))
+  qvm)
+
+;;;;;;;;;;;;;;;;;;;;;;;;; FOWLER-QVM Methods ;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod copy-fowler-qvm ((qvm error-qvm))
+  (let ((new-qvm
+          (make-instance 'error-qvm
+                         :noise-class (fowler-qvm-noise-class qvm)
+                         :noise-probability (fowler-qvm-noise-probability qvm)
+                         :num-qubits (error-qvm-num-qubits qvm)
+                         :gate-definitions (qvm::gate-definitions qvm)
+                         :wait-function (qvm::wait-function qvm)
+                         :classical-memory-subsystem (qvm::classical-memory-subsystem qvm))))
+    (setf (error-qvm-X-vector new-qvm) (copy-seq (error-qvm-X-vector qvm))
+          (error-qvm-Z-vector new-qvm) (copy-seq (error-qvm-Z-vector qvm)))
+    new-qvm))
+
+(defmethod %fast-apply ((qvm error-qvm) instr-name qubit)
+  (cond
+    ((string= "X" instr-name)
+     (setf (aref (error-qvm-X-vector qvm) qubit)
+           (logxor #b1 (aref (error-qvm-X-vector qvm) qubit))))
+    ((string= "Z" instr-name)
+     (setf (aref (error-qvm-Z-vector qvm) qubit)
+           (logxor #b1 (aref (error-qvm-Z-vector qvm) qubit))))
+    ((string= "Y" instr-name)
+     (setf (aref (error-qvm-X-vector qvm) qubit)
+           (logxor #b1 (aref (error-qvm-X-vector qvm) qubit))
+           (aref (error-qvm-Z-vector qvm) qubit)
+           (logxor #b1 (aref (error-qvm-Z-vector qvm) qubit))))
+    (t
+     (error "Bad instruction in %FAST-APPLY: ~a" instr-name))))

--- a/src/error/fowler-noise.lisp
+++ b/src/error/fowler-noise.lisp
@@ -1,0 +1,190 @@
+;;;; fowler-noise.lisp
+;;;;
+;;;; This file is a reparametrization of `DEPOLARIZING-NOISE-QVM', further
+;;;; extended over the stabilizer QVM.  The reparameterization is to match
+;;;; Fowler's convention: a set of flags toggle whether noise is applied after
+;;;; various kinds of gates (see `FOWLER-NOISE'), a single parameter determining
+;;;; the probability of whether noise is _not_ applied after a gate, and in the
+;;;; complementary case uniform probability of the different sorts of Pauli
+;;;; flips one can apply.
+;;;;
+;;;; Fowler further groups the flags into "classes" which assume that one is
+;;;; specifically simulating upkeep for a surface code.  Rather than make that
+;;;; assumption here, we let users implement them as they see fit.
+
+(in-package #:qvm.error)
+
+(deftype fowler-noise ()
+  "Flag enumeration for different kinds of depolarizing noise, following Fowler's classification convention.
+
+HIGH |    4    |   3   |  2 |  1 |   0  | LOW
+---------------------------------------------
+     | READOUT | RESET | 2Q | 1Q | IDLE |"
+  '(unsigned-byte 5))
+
+(define-abstract-class fowler-qvm ()
+  ((noise-probability
+    :initarg :noise-probability
+    :accessor fowler-qvm-noise-probability
+    :type (real 0 1)
+    :documentation "Occurrence probability of a variety of noise events.")
+   (noise-class
+    :initarg :noise-class
+    :initform 31
+    :accessor fowler-qvm-noise-class
+    :type fowler-noise
+    :documentation "Noise events of class <= NOISE-CLASS will be applied."))
+  (:documentation "A quantum virtual machine with noise as specified on page 11 of /1208.0928.
+
+This noise model carries a set of flags that select certain subsets of operations (see `FOWLER-NOISE').  When a flag is set, this noise model applies spatially-uniform depolarizing noise to the corresponding operations.")
+  (:default-initargs :noise-probability 0d0))
+
+(defclass fowler-pure-state-qvm (fowler-qvm pure-state-qvm)
+  ())
+
+(defclass fowler-stabilizer-qvm (fowler-qvm stabilizer-qvm)
+  ())
+
+(defmethod copy-fowler-qvm ((qvm fowler-pure-state-qvm))
+  "Makes a \"deep copy\" of (the quantum part of) `QVM', of type `FOWLER-PURE-STATE-QVM'.
+
+WARNING: Deep copy does _not_ include the classical memory subsystem. Writes to the returned QVM's classical memory will be visible to the original QVM's classical memory, and vice versa."
+  (make-instance 'fowler-pure-state-qvm
+                 :noise-class (fowler-qvm-noise-class qvm)
+                 :noise-probability (fowler-qvm-noise-probability qvm)
+                 :number-of-qubits (number-of-qubits qvm)
+                 :state (make-instance 'pure-state
+                                       :num-qubits (number-of-qubits qvm)
+                                       :amplitudes (alexandria:copy-array
+                                                    (qvm::amplitudes (qvm::state qvm))))
+                 :gate-definitions (qvm::gate-definitions qvm)
+                 :wait-function (qvm::wait-function qvm)
+                 :classical-memory-subsystem (qvm::classical-memory-subsystem qvm)))
+
+(defmethod copy-fowler-qvm ((qvm fowler-stabilizer-qvm))
+  "Makes a \"deep copy\" of (the quantum part of) `QVM', of type `FOWLER-STABILIZER-QVM'.
+
+WARNING: Deep copy does _not_ include the classical memory subsystem. Writes to the returned QVM's classical memory will be visible to the original QVM's classical memory, and vice versa."
+  (make-instance 'fowler-stabilizer-qvm
+                 :noise-class (fowler-qvm-noise-class qvm)
+                 :noise-probability (fowler-qvm-noise-probability qvm)
+                 :tableau (alexandria:copy-array (qvm::stabilizer-qvm-tableau qvm))
+                 :gate-definitions (qvm::gate-definitions qvm)
+                 :wait-function (qvm::wait-function qvm)
+                 :classical-memory-subsystem (qvm::classical-memory-subsystem qvm)))
+
+(defmethod compile-loaded-program ((qvm fowler-qvm))
+  qvm)
+
+;;;
+;;; read individual flags out of the error-type bitvector
+;;;
+
+(defmacro fowler-qvm-noise-identity? (qvm)
+  `(logbitp 0 (fowler-qvm-noise-class ,qvm)))
+
+(defmacro fowler-qvm-noise-1Q-gate? (qvm)
+  `(logbitp 1 (fowler-qvm-noise-class ,qvm)))
+
+(defmacro fowler-qvm-noise-2Q-gate? (qvm)
+  `(logbitp 2 (fowler-qvm-noise-class ,qvm)))
+
+(defmacro fowler-qvm-noise-reset? (qvm)
+  `(logbitp 3 (fowler-qvm-noise-class ,qvm)))
+
+(defmacro fowler-qvm-noise-readout? (qvm)
+  `(logbitp 4 (fowler-qvm-noise-class ,qvm)))
+
+;;;
+;;; basic qvm behavior definitions
+;;;
+
+(defmethod %fast-apply ((qvm fowler-pure-state-qvm) instr-name qubit)
+  (let* ((gate (quil:gate-definition-to-gate (quil:lookup-standard-gate instr-name)))
+         (pure-state (qvm::state qvm)))
+    (apply-gate-to-state gate pure-state (list (quil:qubit qubit)))))
+
+(defmethod %fast-apply ((qvm fowler-stabilizer-qvm) instr-name qubit)
+  (let* ((instr (quil::build-gate instr-name () qubit))
+         (clifford (qvm::gate-application-to-clifford instr)))
+    (apply (qvm::compile-clifford clifford)
+           (qvm::stabilizer-qvm-tableau qvm)
+           (list qubit))))
+
+;;;
+;;; noise behavior definitions
+;;;
+
+(defmethod transition :after ((qvm fowler-qvm) (instr cl-quil:application))
+  (case (length (cl-quil::application-arguments instr))
+    (1
+     (cond
+       ((equalp (quil::named-operator "I")
+                (cl-quil::application-operator instr))
+        (when (fowler-qvm-noise-identity? qvm)
+          (let ((qubit (quil:qubit-index (first (cl-quil::application-arguments instr))))
+                (p/3 (/ (fowler-qvm-noise-probability qvm) 3)))
+            (multiprobabilistically
+              (p/3 (%fast-apply qvm "X" qubit))
+              (p/3 (%fast-apply qvm "Y" qubit))
+              (p/3 (%fast-apply qvm "Z" qubit))))))
+       ((equalp (quil::named-operator "H")
+                (cl-quil::application-operator instr))
+        (when (fowler-qvm-noise-1Q-gate? qvm)
+          (let ((qubit (quil:qubit-index (first (cl-quil::application-arguments instr))))
+                (p/3 (/ (fowler-qvm-noise-probability qvm) 3)))
+            (multiprobabilistically
+              (p/3 (%fast-apply qvm "X" qubit))
+              (p/3 (%fast-apply qvm "Y" qubit))
+              (p/3 (%fast-apply qvm "Z" qubit))))))
+       (t
+        (break)
+        (warn "FOWLER-QVM doesn't know how to follow ~a with depolarizing noise"
+              instr))))
+    (2
+     (cond
+       ((equalp (quil::named-operator "CNOT")
+                     (cl-quil::application-operator instr))
+        (when (fowler-qvm-noise-2Q-gate? qvm)
+          ;; apply a non-II pauli each w/ probability p/15
+          (let ((p (quil:qubit-index (first  (cl-quil::application-arguments instr))))
+                (q (quil:qubit-index (second (cl-quil::application-arguments instr))))
+                (p/15 (/ (fowler-qvm-noise-probability qvm) 15)))
+            (multiprobabilistically
+              (p/15 (%fast-apply qvm "X" p))
+              (p/15 (%fast-apply qvm "Y" p))
+              (p/15 (%fast-apply qvm "Z" p))
+              (p/15 (%fast-apply qvm "X" q))
+              (p/15 (%fast-apply qvm "Y" q))
+              (p/15 (%fast-apply qvm "Z" q))
+              (p/15 (%fast-apply qvm "X" p) (%fast-apply qvm "X" q))
+              (p/15 (%fast-apply qvm "X" p) (%fast-apply qvm "Y" q))
+              (p/15 (%fast-apply qvm "X" p) (%fast-apply qvm "Z" q))
+              (p/15 (%fast-apply qvm "Y" p) (%fast-apply qvm "X" q))
+              (p/15 (%fast-apply qvm "Y" p) (%fast-apply qvm "Y" q))
+              (p/15 (%fast-apply qvm "Y" p) (%fast-apply qvm "Z" q))
+              (p/15 (%fast-apply qvm "Z" p) (%fast-apply qvm "X" q))
+              (p/15 (%fast-apply qvm "Z" p) (%fast-apply qvm "Y" q))
+              (p/15 (%fast-apply qvm "Z" p) (%fast-apply qvm "Z" q))))))
+       (t
+        (break)
+        (warn "FOWLER-QVM doesn't know how to follow ~a with depolarizing noise"
+              instr))))
+    (otherwise
+     (break)
+     (warn "FOWLER-QVM doesn't know how to follow ~a with depolarizing noise"
+           instr))))
+
+(defmethod transition :after ((qvm fowler-qvm) (instr cl-quil:reset-qubit))
+  ;; attempt to initialize to |g>, but initialize instead to |e> w/ probability p
+  (when (fowler-qvm-noise-reset? qvm)
+    (qvm::probabilistically (fowler-qvm-noise-probability qvm)
+      (let ((qubit (quil:qubit-index (quil::reset-qubit-target instr))))
+        (%fast-apply qvm "X" qubit)))))
+
+(defmethod transition :before ((qvm fowler-qvm) (instr cl-quil:measurement))
+  ;; attempt to perform Z-meas, but report and project to wrong state w/ probability p
+  (when (fowler-qvm-noise-readout? qvm)
+    (qvm::probabilistically (fowler-qvm-noise-probability qvm)
+      (let ((qubit (quil:qubit-index (cl-quil:measurement-qubit instr))))
+        (%fast-apply qvm "X" qubit)))))

--- a/src/error/package.lisp
+++ b/src/error/package.lisp
@@ -1,0 +1,19 @@
+;;;; error/package.lisp
+;;;;
+;;;; This subpackage houses some QVM variants useful for tracing errors through
+;;;; circuits which are expected to measure out 0s in the absence of noise.
+
+(defpackage #:qvm.error
+  (:use #:cl
+        #:abstract-classes
+        #:qvm)
+  (:import-from #:qvm #:multiprobabilistically)
+  (:local-nicknames (#:quil     #:cl-quil.frontend))
+  
+  (:export
+   #:fowler-pure-state-qvm              ; CLASS
+   #:fowler-stabilizer-qvm              ; CLASS
+   #:error-qvm                          ; CLASS
+   #:make-error-qvm                     ; CONSTRUCTOR
+   #:copy-fowler-qvm                    ; COPY-CONSTRUCTOR
+   ))

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -128,6 +128,25 @@ NOTE: This will not copy any multiprocessing aspects."
   `(when (< (random 1.0) ,p)
      ,@body))
 
+(defmacro multiprobabilistically (&body clauses)
+  "Given several `CLAUSES' of the form (PROB &BODY BODY), pick a given clause with probability `PROB', execute its `BODY', and return."
+  (let ((amount-names (loop :for clause :in clauses :collect (gensym)))
+        (block-name (gensym))
+        (random-name (gensym)))
+    `(block ,block-name
+       (let* (,@(loop :for amount-name :in amount-names
+                      :for (probability . body) :in clauses
+                      :collect `(,amount-name ,probability)))
+         (assert (<= (+ ,@amount-names) 1d0))
+         (let ((,random-name (random 1d0)))
+           ,@(loop :for amount-name :in amount-names
+                   :for (probability . body) :in clauses
+                   :collect `(when (< ,random-name ,amount-name)
+                               ,@body
+                               (return-from ,block-name))
+                   :collect `(decf ,random-name ,amount-name))
+           nil)))))
+
 (defmacro defun-inlinable (name lambda-list &body body)
   "Define an INLINE-able function."
   `(progn

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -130,7 +130,7 @@ NOTE: This will not copy any multiprocessing aspects."
 
 (defmacro multiprobabilistically (&body clauses)
   "Given several `CLAUSES' of the form (PROB &BODY BODY), pick a given clause with probability `PROB', execute its `BODY', and return."
-  (let ((amount-names (loop :for clause :in clauses :collect (gensym)))
+  (let ((amount-names (loop :for clause :in clauses :collect (gensym "AMOUNT")))
         (block-name (gensym))
         (random-name (gensym)))
     `(block ,block-name

--- a/tests/error-qvm-tests.lisp
+++ b/tests/error-qvm-tests.lisp
@@ -53,7 +53,7 @@ CLAUSES is a sequence of clauses, each of the form ( SETF-FORM . INSTRUCTIONS ),
              (maphash (lambda (key true-value)
                         (let* ((recorded-hits (gethash key ,histogram 0d0))
                                (estimated-value (/ recorded-hits ,trials)))
-                          (format *error-output* "Checking ~8b: ~5f < ~5f < ~5f, estimated mean: ~d / ~d = ~5f~%"
+                          (format *error-output* "~&Checking ~8b: ~5f < ~5f < ~5f, estimated mean: ~d / ~d = ~5f~%"
                                   key
                                   (- estimated-value ,confidence-window)
                                   true-value

--- a/tests/error-qvm-tests.lisp
+++ b/tests/error-qvm-tests.lisp
@@ -1,0 +1,202 @@
+;;;; tests/error-qvm-tests.lisp
+;;;;
+;;;; Tests the behavior of depolarizing noise in the Error QVM.
+
+(in-package #:qvm-tests)
+
+(defun build-measure (qubit-index memory-offset)
+  (make-instance 'cl-quil::measure
+                 :qubit (cl-quil::qubit qubit-index)
+                 :address (cl-quil::mref "ro" memory-offset)))
+
+(defmacro define-depolarizing-test
+    (name (&key num-qubits distribution trials
+                (alpha 0.5d0))
+     &body clauses)
+  "Sets up scaffolding for a test which sanity-checks the depolarizing noise QVM.
+
+NAME is the name of the test.
+NUM-QUBITS is the number of qubits (and memory registers) involved in the test.
+DISTRIBUTION is a p-list mapping bitstrings to expected probabilities.
+TRIALS is the number of trials to simulate.
+ALPHA is the width of the confidence window: 1.0 tests nothing, 0.0 requires exact agreement, 0.5 means we require that we're 50% confident that our sampled estimate is within Hoeffding's bound of the true distribution.
+CLAUSES is a sequence of clauses, each of the form ( SETF-FORM . INSTRUCTIONS ), where SETF-FORM is a single form to be executed (typically to set the QVM's noise slots) and INSTRUCTIONS is a sequence of CL-QUIL instructions along which the QVM will transition."
+  (alexandria:with-gensyms (histogram)
+    (multiple-value-bind (clauses decls docstring)
+        (alexandria:parse-body clauses :documentation t)
+      (assert (null decls))
+      (let ((confidence-window (sqrt (/ (log (/ 2 (- 1 alpha))) (* 2 trials)))))
+        `(deftest ,name ()
+           ,@(when docstring `(,docstring))
+           (let ((,histogram (make-hash-table)))
+             (dotimes (j ,trials)
+               (let* ((quil-string (format nil "DECLARE ro BIT[~A]" ,num-qubits))
+                      (memory-model (qvm:memory-descriptors-to-qvm-memory-model
+                                     (quil:parsed-program-memory-definitions
+                                      (quil::parse-quil quil-string))))
+                      (qvm (qvm.error::make-error-qvm ,num-qubits
+                                                      :classical-memory-model memory-model)))
+                 ;; enact clauses
+                 ,@(loop :for (setf-form . transitions) :in clauses
+                         :collect `(progn
+                                     ,setf-form
+                                     ,@(loop :for transition :in transitions
+                                             :collect `(qvm::transition qvm ,transition))))
+                 ;; record results
+                 (qvm::dereference-mref qvm (cl-quil::mref "ro" 0))
+                 (loop :with acc := 0
+                       :for i :from (1- ,num-qubits) :downto 0
+                       :do (setf acc (* acc 2)
+                                 acc (+ acc (qvm::dereference-mref qvm (cl-quil::mref "ro" i))))
+                       :finally (incf (gethash acc ,histogram 0)))))
+             ;; check our estimates
+             (maphash (lambda (key true-value)
+                        (let* ((recorded-hits (gethash key ,histogram 0d0))
+                               (estimated-value (/ recorded-hits ,trials)))
+                          (format *error-output* "Checking ~8b: ~5f < ~5f < ~5f, estimated mean: ~d / ~d = ~5f~%"
+                                  key
+                                  (- estimated-value ,confidence-window)
+                                  true-value
+                                  (+ estimated-value ,confidence-window)
+                                  (gethash key ,histogram 0d0)
+                                  ,trials
+                                  estimated-value)))
+                      (alexandria:plist-hash-table ,distribution))
+             (maphash (lambda (key true-value)
+                        (let* ((recorded-hits (gethash key ,histogram 0d0))
+                               (estimated-value (/ recorded-hits ,trials)))
+                          (is (< (- estimated-value ,confidence-window)
+                                 true-value
+                                 (+ estimated-value ,confidence-window)))))
+                      (alexandria:plist-hash-table ,distribution))))))))
+
+(define-depolarizing-test test-identity-noise
+    (:num-qubits 1
+     :distribution '(#b0 #.(- 1 (* 0.1 2/3)) #b1 #.(* 0.1 2/3))
+     :trials 1000)
+  "Checks that depolarizing noise acts as expected on the identity gate."
+  ;; run a noisy I gate
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1
+         (qvm.error::fowler-qvm-noise-class qvm) #b11111)
+   (cl-quil::build-gate "I" () 0))
+  ;; perform a perfect measurement
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0)
+   (build-measure 0 0)))
+
+(define-depolarizing-test test-identity-noise-2q
+    (:num-qubits 2
+     :distribution '(#b00 #.(- 1 (+ (* 0.1 2/3) (* 0.1 2/3) (* 0.1 2/3 0.1 2/3)))
+                     #b01 #.(* 0.1 2/3)
+                     #b10 #.(* 0.1 2/3)
+                     #b11 #.(* 0.1 0.1 2/3 2/3))
+     :alpha 0.9d0
+     :trials 1000)
+  "Checks that depolarizing noise acts as expected on the identity gate."
+  ;; run two noisy I gates
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1
+         (qvm.error::fowler-qvm-noise-class qvm) #b11111)
+   (cl-quil::build-gate "I" () 0)
+   (cl-quil::build-gate "I" () 1))
+  ;; perform two perfect measurements
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0)
+   (build-measure 0 0)
+   (build-measure 1 1)))
+
+(define-depolarizing-test test-H-noise
+    (:num-qubits 1
+     :distribution '(#b0 #.(- 1 (* 0.1 2/3)) #b1 #.(* 0.1 2/3))
+     :alpha 0.9d0
+     :trials 1000)
+  "Checks that noise in momentum space matches noise in position space."
+  ;; run a noisy H gate
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1
+         (qvm.error::fowler-qvm-noise-class qvm) #b11111)
+   (cl-quil::build-gate "H" () 0))
+  ;; perform a perfect un-compute and measure
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0)
+   (cl-quil::build-gate "H" () 0)
+   (build-measure 0 0)))
+
+(define-depolarizing-test test-CNOT-noise
+    (:num-qubits 2
+     :distribution '(;; 1-p and 3 of p/15 options flip neither bit
+                     #b00 #.(+ (- 1 0.1) (* 0.1 3/15))
+                     ;; 4 of p/15 options flip only the first bit
+                     #b01 #.(* 0.1 4/15)
+                     ;; 4 of p/15 options flip only the second bit (and then CNOT flips the other)
+                     #b11 #.(* 0.1 4/15)
+                     ;; 4 of p/15 options flip both bits (and then CNOT un-flips)
+                     #b10 #.(* 0.1 4/15))
+     :alpha 0.9d0
+     :trials 1000)
+  "Checks that CNOT propagates noise appropriately."
+  ;; run a noisy CNOT gate
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1
+         (qvm.error::fowler-qvm-noise-class qvm) #b11111)
+   (cl-quil::build-gate "CNOT" () 0 1))
+  ;; perform a perfect un-compute and measure
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0)
+   (cl-quil::build-gate "CNOT" () 0 1)
+   (build-measure 0 0)
+   (build-measure 1 1)))
+
+(define-depolarizing-test test-CNOT-noise-cat-state
+    (:num-qubits 2
+     :distribution '(;; 1-p and 3 of p/15 options flip neither bit
+                     #b00 #.(+ (- 1 0.1) (* 0.1 3/15))
+                     ;; 4 of p/15 options flip only the first bit
+                     #b01 #.(* 0.1 4/15)
+                     ;; 4 of p/15 options flip only the second bit (and then CNOT flips the other)
+                     #b11 #.(* 0.1 4/15)
+                     ;; 4 of p/15 options flip both bits (and then CNOT un-flips)
+                     #b10 #.(* 0.1 4/15))
+     :alpha 0.9d0
+     :trials 1000)
+  "Checks that CNOT propagates noise appropriately."
+  ;; prepare a perfect |0+> state
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0
+         (qvm.error::fowler-qvm-noise-class qvm) #b11111)
+   (cl-quil::build-gate "H" () 0))
+  ;; run a noisy CNOT gate
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1)
+   (cl-quil::build-gate "CNOT" () 0 1))
+  ;; perform a perfect un-compute and measure
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0)
+   (cl-quil::build-gate "CNOT" () 0 1)
+   (cl-quil::build-gate "H" () 0)
+   (build-measure 0 0)
+   (build-measure 1 1)))
+
+(define-depolarizing-test test-measurement-noise
+    (:num-qubits 2
+     :distribution '(;; no flip
+                     #b00 #.(* (- 1 0.1) (- 1 0.1))
+                     ;; flip second, not first
+                     #b10 #.(* (- 1 0.1) 0.1)
+                     ;; flip first, not second
+                     #b11 #.(* (- 1 0.1) 0.1)
+                     ;; flip both times
+                     #b01 #.(* 0.1 0.1))
+     :alpha 0.9d0
+     :trials 1000)
+  "Checks that MEASURE injects some noise."
+  ;; run two noisy measurements in succession
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1
+         (qvm.error::fowler-qvm-noise-class qvm) #b11111)
+   (build-measure 0 0)
+   (build-measure 0 1)))
+
+(define-depolarizing-test test-reset-noise
+    (:num-qubits 1
+     :distribution '(#b0 #.(- 1 0.1)
+                     #b1 0.1)
+     :alpha 0.9d0
+     :trials 1000)
+  "Checks that MEASURE injects some noise."
+  ;; reset a noisy qubit
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1
+         (qvm.error::fowler-qvm-noise-class qvm) #b11111)
+   (make-instance 'cl-quil::reset-qubit :target (cl-quil::qubit 0)))
+  ;; run an error-free measurement
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0)
+   (build-measure 0 0)))

--- a/tests/error-qvm-tests.lisp
+++ b/tests/error-qvm-tests.lisp
@@ -72,70 +72,70 @@ CLAUSES is a sequence of clauses, each of the form ( SETF-FORM . INSTRUCTIONS ),
 
 (define-depolarizing-test test-identity-noise
     (:num-qubits 1
-     :distribution '(#b0 #.(- 1 (* 0.1 2/3)) #b1 #.(* 0.1 2/3))
+     :distribution '(#b0 #.(- 1 (* 1d-1 2/3)) #b1 #.(* 1d-1 2/3))
      :trials 1000)
   "Checks that depolarizing noise acts as expected on the identity gate."
   ;; run a noisy I gate
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 1d-1
          (qvm.error::fowler-qvm-noise-class qvm) #b11111)
    (cl-quil::build-gate "I" () 0))
   ;; perform a perfect measurement
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0)
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0d0)
    (build-measure 0 0)))
 
 (define-depolarizing-test test-identity-noise-2q
     (:num-qubits 2
-     :distribution '(#b00 #.(- 1 (+ (* 0.1 2/3) (* 0.1 2/3) (* 0.1 2/3 0.1 2/3)))
-                     #b01 #.(* 0.1 2/3)
-                     #b10 #.(* 0.1 2/3)
-                     #b11 #.(* 0.1 0.1 2/3 2/3))
+     :distribution '(#b00 #.(- 1 (+ (* 1d-1 2/3) (* 1d-1 2/3) (* 1d-1 2/3 1d-1 2/3)))
+                     #b01 #.(* 1d-1 2/3)
+                     #b10 #.(* 1d-1 2/3)
+                     #b11 #.(* 1d-1 1d-1 2/3 2/3))
      :alpha 0.9d0
      :trials 1000)
   "Checks that depolarizing noise acts as expected on the identity gate."
   ;; run two noisy I gates
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 1d-1
          (qvm.error::fowler-qvm-noise-class qvm) #b11111)
    (cl-quil::build-gate "I" () 0)
    (cl-quil::build-gate "I" () 1))
   ;; perform two perfect measurements
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0)
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0d0)
    (build-measure 0 0)
    (build-measure 1 1)))
 
 (define-depolarizing-test test-H-noise
     (:num-qubits 1
-     :distribution '(#b0 #.(- 1 (* 0.1 2/3)) #b1 #.(* 0.1 2/3))
+     :distribution '(#b0 #.(- 1 (* 1d-1 2/3)) #b1 #.(* 1d-1 2/3))
      :alpha 0.9d0
      :trials 1000)
   "Checks that noise in momentum space matches noise in position space."
   ;; run a noisy H gate
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 1d-1
          (qvm.error::fowler-qvm-noise-class qvm) #b11111)
    (cl-quil::build-gate "H" () 0))
   ;; perform a perfect un-compute and measure
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0)
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0d0)
    (cl-quil::build-gate "H" () 0)
    (build-measure 0 0)))
 
 (define-depolarizing-test test-CNOT-noise
     (:num-qubits 2
      :distribution '(;; 1-p and 3 of p/15 options flip neither bit
-                     #b00 #.(+ (- 1 0.1) (* 0.1 3/15))
+                     #b00 #.(+ (- 1 1d-1) (* 1d-1 3/15))
                      ;; 4 of p/15 options flip only the first bit
-                     #b01 #.(* 0.1 4/15)
+                     #b01 #.(* 1d-1 4/15)
                      ;; 4 of p/15 options flip only the second bit (and then CNOT flips the other)
-                     #b11 #.(* 0.1 4/15)
+                     #b11 #.(* 1d-1 4/15)
                      ;; 4 of p/15 options flip both bits (and then CNOT un-flips)
-                     #b10 #.(* 0.1 4/15))
+                     #b10 #.(* 1d-1 4/15))
      :alpha 0.9d0
      :trials 1000)
   "Checks that CNOT propagates noise appropriately."
   ;; run a noisy CNOT gate
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 1d-1
          (qvm.error::fowler-qvm-noise-class qvm) #b11111)
    (cl-quil::build-gate "CNOT" () 0 1))
   ;; perform a perfect un-compute and measure
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0)
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0d0)
    (cl-quil::build-gate "CNOT" () 0 1)
    (build-measure 0 0)
    (build-measure 1 1)))
@@ -143,25 +143,25 @@ CLAUSES is a sequence of clauses, each of the form ( SETF-FORM . INSTRUCTIONS ),
 (define-depolarizing-test test-CNOT-noise-cat-state
     (:num-qubits 2
      :distribution '(;; 1-p and 3 of p/15 options flip neither bit
-                     #b00 #.(+ (- 1 0.1) (* 0.1 3/15))
+                     #b00 #.(+ (- 1 1d-1) (* 1d-1 3/15))
                      ;; 4 of p/15 options flip only the first bit
-                     #b01 #.(* 0.1 4/15)
+                     #b01 #.(* 1d-1 4/15)
                      ;; 4 of p/15 options flip only the second bit (and then CNOT flips the other)
-                     #b11 #.(* 0.1 4/15)
+                     #b11 #.(* 1d-1 4/15)
                      ;; 4 of p/15 options flip both bits (and then CNOT un-flips)
-                     #b10 #.(* 0.1 4/15))
+                     #b10 #.(* 1d-1 4/15))
      :alpha 0.9d0
      :trials 1000)
   "Checks that CNOT propagates noise appropriately."
   ;; prepare a perfect |0+> state
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0d0
          (qvm.error::fowler-qvm-noise-class qvm) #b11111)
    (cl-quil::build-gate "H" () 0))
   ;; run a noisy CNOT gate
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1)
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 1d-1)
    (cl-quil::build-gate "CNOT" () 0 1))
   ;; perform a perfect un-compute and measure
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0)
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0d0)
    (cl-quil::build-gate "CNOT" () 0 1)
    (cl-quil::build-gate "H" () 0)
    (build-measure 0 0)
@@ -170,33 +170,33 @@ CLAUSES is a sequence of clauses, each of the form ( SETF-FORM . INSTRUCTIONS ),
 (define-depolarizing-test test-measurement-noise
     (:num-qubits 2
      :distribution '(;; no flip
-                     #b00 #.(* (- 1 0.1) (- 1 0.1))
+                     #b00 #.(* (- 1 1d-1) (- 1 1d-1))
                      ;; flip second, not first
-                     #b10 #.(* (- 1 0.1) 0.1)
+                     #b10 #.(* (- 1 1d-1) 1d-1)
                      ;; flip first, not second
-                     #b11 #.(* (- 1 0.1) 0.1)
+                     #b11 #.(* (- 1 1d-1) 1d-1)
                      ;; flip both times
-                     #b01 #.(* 0.1 0.1))
+                     #b01 #.(* 1d-1 1d-1))
      :alpha 0.9d0
      :trials 1000)
   "Checks that MEASURE injects some noise."
   ;; run two noisy measurements in succession
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 1d-1
          (qvm.error::fowler-qvm-noise-class qvm) #b11111)
    (build-measure 0 0)
    (build-measure 0 1)))
 
 (define-depolarizing-test test-reset-noise
     (:num-qubits 1
-     :distribution '(#b0 #.(- 1 0.1)
-                     #b1 0.1)
+     :distribution '(#b0 #.(- 1 1d-1)
+                     #b1 1d-1)
      :alpha 0.9d0
      :trials 1000)
   "Checks that MEASURE injects some noise."
   ;; reset a noisy qubit
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.1
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 1d-1
          (qvm.error::fowler-qvm-noise-class qvm) #b11111)
    (make-instance 'cl-quil::reset-qubit :target (cl-quil::qubit 0)))
   ;; run an error-free measurement
-  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0.0)
+  ((setf (qvm.error::fowler-qvm-noise-probability qvm) 0d0)
    (build-measure 0 0)))


### PR DESCRIPTION
The PR introduces two further variants of noisy QVMs:

1. `fowler-qvm`: A variant of `stabilizer-qvm` which injects depolarizing noise after "basic" operations. "Basic" operations are divided into types (identity, nontrivial 1Q, 2Q, measure, reset), and noise can be selectively toggled for each of these types. (I think that in the current implementation these types are explicitly given by named gates, e.g., `I` and `H`, as opposed to any ol' 1Q Clifford.) This class type is named `fowler-qvm` rather than `depolarizing-stabilizer-qvm` because of this toggling ability, which is a slightly different noise model than straight-up depolarizing noise; to our knowledge, this modified noise model was specified by Austin Fowler in work on topological error correction.
2. `error-qvm`: A restriction of `fowler-qvm` to circuits which, when performed without noise, are guaranteed to always measure 0. Under this assumption, we can propagate through the circuit the Pauli errors arising in depolarizing noise, rather than tracking anything like the underlying quantum state, so that the space complexity becomes linear in qubit count. A similar simulator can be found in [Autotune](https://github.com/adamcw/autotune).

This PR is joint work with @karalekas, carried out in 2020 under the Eigenware umbrella.

Happy to take advice; I don't feel that this code perfectly conforms to existing QVM code style.