### PR TITLE
fix: catch unbound alien variable when building on arm64

### DIFF
--- a/qvm.asd
+++ b/qvm.asd
@@ -3,7 +3,7 @@
 ;;;; Author: Robert Smith
 
 #+(and sbcl x86-64)
-#.(when (sb-alien:extern-alien "avx2_supported" sb-alien:int)
+#.(when (ignore-errors (sb-alien:extern-alien "avx2_supported" sb-alien:int))
     (cl:push :qvm-avx2 cl:*features*)
     (values))
 


### PR DESCRIPTION
Closes #306 . I've confirmed this change enabled a smooth build on our Ampere box.

This alone doesn't solve the ARM64 build - there are some changes needed in cffi as well, which I'll take a look at later this week.