### PR TITLE
Provide type description fragment in allocate-memory-for-model error

### DIFF
--- a/src/classical-memory.lisp
+++ b/src/classical-memory.lisp
@@ -287,7 +287,7 @@ If BYPASS-SIZE-LIMIT is T (default: NIL), then the size limit dictated by **CLAS
                         ;; model is right.
                         8)
           :do
-             (check-type size (integer 1) "The SIZE wasn't a multiple of 8.")
+             (check-type size (integer 1) "a multiple of 8")
              ;; Record this allocation
              (decf size-left size)
              ;; Check we haven't overflowed.


### PR DESCRIPTION
Minor nit: changes error message from

    The value of QVM::SIZE is 0, which is not The SIZE wasn't a multiple of 8..

to

    The value of QVM::SIZE is 0, which is not a multiple of 8.